### PR TITLE
Feature: Add batchSize to enable multiple messages to be consumed at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ app.start();
 * The queue is polled continuously for messages using [long polling](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html).
 * Messages are deleted from the queue once `done()` is called.
 * Calling `done(err)` with an error object will cause the message to be left on the queue. An [SQS redrive policy](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html) can be used to move messages that cannot be processed to a dead letter queue.
+* By default messages are processed one at a time – a new message won't be received until the first one has been processed. To process messages in parallel, use the `batchSize` option [detailed below](#options).
 
 ## API
 
@@ -47,7 +48,7 @@ Creates a new SQS consumer.
 * `queueUrl` - _String_ - The SQS queue URL
 * `region` - _String_ - The AWS region
 * `handleMessage` - _Function_ - A function to be called whenever a message is receieved. Receives an SQS message object as its first argument and a function to call when the message has been handled as its second argument (i.e. `handleMessage(message, done)`).
-* `waitTime` - _Number_ - An optional time in milliseconds to wait after recieving a message before requesting another one. This enables you to throttle the rate at which messages will be received. (default `100`);
+* `batchSize` - _Number_ - The number of messages to request from SQS when polling (default `1`). This cannot be higher than the AWS limit of 10.
 * `sqs` - _Object_ - An optional [AWS SQS](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html) object to use if you need to configure the client manually
 
 ### `consumer.start()`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-consumer",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Build SQS-based Node applications without the boilerplate",
   "main": "index.js",
   "scripts": {
@@ -26,6 +26,7 @@
     "sinon": "^1.10.3"
   },
   "dependencies": {
+    "async": "^0.9.0",
     "aws-sdk": "^2.0.23",
     "debug": "^2.1.0",
     "lodash": "^2.4.1"


### PR DESCRIPTION
* Allows up to 10 messages to be requested from SQS at a time
* Uses `async.each` to process multiple messages.
* Removes the `waitTime` parameter. The consumer now waits until the current batch of messages has been processed before requesting a new batch. This applies to single messages as well. This provides some back pressure on the queue, rather than blindly pulling messages at a fixed rate.