### PR TITLE
Add .create function to match sqs-producer

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,13 @@ function Consumer(options) {
 util.inherits(Consumer, EventEmitter);
 
 /**
+ * Construct a new Consumer
+ */
+Consumer.create = function(options) {
+    return new Consumer(options);
+};
+
+/**
  * Start polling for messages.
  */
 Consumer.prototype.start = function () {

--- a/test/index.js
+++ b/test/index.js
@@ -77,6 +77,19 @@ describe('Consumer', function () {
     });
   });
 
+  describe('.create', function () {
+    it('creates a new instance of a Consumer object', function() {
+        var consumer = Consumer.create({
+            region: 'some-region',
+            queueUrl: 'some-queue-url',
+            batchSize: 1,
+            handleMessage: handleMessage
+        });
+
+        assert(consumer instanceof Consumer);
+    });
+  });
+
   describe('.start', function () {
     it('fires an error event when an error occurs receiving a message', function (done) {
       var receiveErr = new Error('Receive error');


### PR DESCRIPTION
As a user of both sqs-consumer and sqs-producer I want a consistent way to interact with them. To facilitate this either the object needs exporting on sqs-producer or a .create function creating on the sqs-consumer which seems simpler and less intrusive.