### PR TITLE
Make SQS Region config value optional. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ var Consumer = require('sqs-consumer');
 
 var app = Consumer.create({
   queueUrl: 'https://sqs.eu-west-1.amazonaws.com/account-id/queue-name',
-  region: 'eu-west-1',
   handleMessage: function (message, done) {
     // do some work with `message`
     done();
@@ -46,7 +45,7 @@ Creates a new SQS consumer.
 #### Options
 
 * `queueUrl` - _String_ - The SQS queue URL
-* `region` - _String_ - The AWS region
+* `region` - _String_ - The AWS region (default `eu-west-1`)
 * `handleMessage` - _Function_ - A function to be called whenever a message is receieved. Receives an SQS message object as its first argument and a function to call when the message has been handled as its second argument (i.e. `handleMessage(message, done)`).
 * `batchSize` - _Number_ - The number of messages to request from SQS when polling (default `1`). This cannot be higher than the AWS limit of 10.
 * `sqs` - _Object_ - An optional [AWS SQS](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html) object to use if you need to configure the client manually

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ var AWS = require('aws-sdk');
 var debug = require('debug')('sqs-consumer');
 var requiredOptions = [
     'queueUrl',
-    'region',
     'handleMessage'
   ];
 
@@ -40,7 +39,7 @@ function Consumer(options) {
   this.stopped = true;
   this.batchSize = options.batchSize || 1;
   this.sqs = options.sqs || new AWS.SQS({
-    region: options.region
+    region: options.region || 'eu-west-1'
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var _ = require('lodash');

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
-var _ = require('lodash');
 var async = require('async');
 var AWS = require('aws-sdk');
 var debug = require('debug')('sqs-consumer');

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "async": "^0.9.0",
     "aws-sdk": "^2.0.23",
     "codeclimate-test-reporter": "0.0.4",
-    "debug": "^2.1.0",
-    "lodash": "^2.4.1"
+    "debug": "^2.1.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Consumer = require('..');
 var assert = require('assert');
 var sinon = require('sinon');
@@ -32,15 +34,6 @@ describe('Consumer', function () {
     assert.throws(function () {
       new Consumer({
         region: 'some-region',
-        handleMessage: handleMessage
-      });
-    });
-  });
-
-  it('requires an AWS region to be set', function () {
-    assert.throws(function () {
-      new Consumer({
-        queueUrl: 'some-queue-url',
         handleMessage: handleMessage
       });
     });


### PR DESCRIPTION
As it is already specified on SQS instance creation like:

```js
// Init AWS credentials
AWS.config.update({
		accessKeyId: process.env.AWS_ACCESS_KEY,
		secretAccessKey: process.env.AWS_ACCESS_SECRET,
		region: process.env.AWS_ACCESS_REGION
	});

// Init SQS service
var sqs = new AWS.SQS();
...
```

and used as:

```js
	var app = Consumer.create({
		queueUrl: queues.smtp.QueueUrl,
		sqs: sqs,
		handleMessage: function (message, done) {
			// do some work with `message`
			done();
		}
	});
```