### PR TITLE
add optional callback for stopping the consumer

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,9 +93,10 @@ Consumer.prototype.start = function () {
 /**
  * Stop polling for messages.
  */
-Consumer.prototype.stop = function () {
+Consumer.prototype.stop = function (done) {
   debug('Stopping consumer');
   this.stopped = true;
+  this.handleStop = done;
 };
 
 Consumer.prototype._poll = function () {
@@ -107,6 +108,10 @@ Consumer.prototype._poll = function () {
     WaitTimeSeconds: this.waitTimeSeconds,
     VisibilityTimeout: this.visibilityTimeout
   };
+  
+  if (this.handleStop) {
+    this.handleStop();
+  }
 
   if (!this.stopped) {
     debug('Polling for messages');

--- a/test/index.js
+++ b/test/index.js
@@ -347,5 +347,17 @@ describe('Consumer', function () {
         done();
       }, 10);
     });
+
+    it('calls stop callback', function (done) {
+      var handleStop = sinon.stub();
+
+      consumer.start();
+      consumer.stop(handleStop);
+
+      setTimeout(function () {
+        sinon.assert.calledOnce(handleStop);
+        done();
+      }, 10);
+    });
   });
 });


### PR DESCRIPTION
Hi,

I have a similar need as #15 as I'm running Node on AWS and ECS/Docker notifies a running container with a SIGTERM when it should be stopped. And as I'd like to handle this in a correct way, here is the proposal for it.