### PR TITLE
emit a stopped event when stopping the consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,4 @@ Each consumer is an [`EventEmitter`](http://nodejs.org/api/events.html) and emit
 |`processing_error`|`err`|Fired when an error occurs processing the message.|
 |`message_received`|`message`|Fired when a message is received.|
 |`message_processed`|`message`|Fired when a message is successfully processed and removed from the queue.|
+|`stopped`|None|Fired when the consumer finally stops its work.|

--- a/index.js
+++ b/index.js
@@ -111,6 +111,8 @@ Consumer.prototype._poll = function () {
   if (!this.stopped) {
     debug('Polling for messages');
     this.sqs.receiveMessage(receiveParams, this._handleSqsResponseBound);
+  } else {
+    this.emit('stopped');
   }
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -335,15 +335,63 @@ describe('Consumer', function () {
   });
 
   describe('.stop', function () {
-    it('stops the consumer polling for messages', function (done) {
+    beforeEach(function () {
       sqs.receiveMessage.onSecondCall().yieldsAsync(null, response);
       sqs.receiveMessage.onThirdCall().returns();
+    });
 
+    it('stops the consumer polling for messages', function (done) {
       consumer.start();
       consumer.stop();
 
       setTimeout(function () {
         sinon.assert.calledOnce(handleMessage);
+        done();
+      }, 10);
+    });
+
+    it('fires a stopped event when last poll occurs after stopping', function (done) {
+      var handleStop = sinon.stub().returns();
+
+      consumer.on('stopped', handleStop);
+
+      consumer.start();
+      consumer.stop();
+
+      setTimeout(function () {
+        sinon.assert.calledOnce(handleStop);
+        done();
+      }, 10);
+    });
+
+    it('fires a stopped event only once when stopped multiple times', function (done) {
+      var handleStop = sinon.stub().returns();
+
+      consumer.on('stopped', handleStop);
+
+      consumer.start();
+      consumer.stop();
+      consumer.stop();
+      consumer.stop();
+
+      setTimeout(function () {
+        sinon.assert.calledOnce(handleStop);
+        done();
+      }, 10);
+    });
+
+    it('fires a stopped event a second time if started and stopped twice', function (done) {
+      var handleStop = sinon.stub().returns();
+
+      consumer.on('stopped', handleStop);
+
+      consumer.start();
+      consumer.stop();
+      consumer.start();
+      consumer.stop();
+
+      setTimeout(function () {
+        sinon.assert.calledTwice(handleStop);
         done();
       }, 10);
     });


### PR DESCRIPTION
Continues from #39:

> I have a similar need as #15 as I'm running Node on AWS and ECS/Docker notifies a running container with a SIGTERM when it should be stopped. And as I'd like to handle this in a correct way, here is the proposal for it.