### PR TITLE
Add empty queue event

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Creates a new SQS consumer.
 * `waitTimeSeconds` - _Number_ - The duration (in seconds) for which the call will wait for a message to arrive in the queue before returning.
 * `authenticationErrorTimeout` - _Number_ - The duration (in milliseconds) to wait before retrying after an authentication error (defaults to `10000`).
 * `sqs` - _Object_ - An optional [AWS SQS](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html) object to use if you need to configure the client manually
+* `emptyQueueEvent` - _Boolean_ - If you want to know when the queue is empty active this flag (will emit an event). Default will not do
 
 ### `consumer.start()`
 
@@ -112,3 +113,4 @@ Each consumer is an [`EventEmitter`](http://nodejs.org/api/events.html) and emit
 |`message_received`|`message`|Fired when a message is received.|
 |`message_processed`|`message`|Fired when a message is successfully processed and removed from the queue.|
 |`stopped`|None|Fired when the consumer finally stops its work.|
+|`emptyQueue`|None|Fired when the queue is empty (All messages have been consumed).|

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Creates a new SQS consumer.
 * `waitTimeSeconds` - _Number_ - The duration (in seconds) for which the call will wait for a message to arrive in the queue before returning.
 * `authenticationErrorTimeout` - _Number_ - The duration (in milliseconds) to wait before retrying after an authentication error (defaults to `10000`).
 * `sqs` - _Object_ - An optional [AWS SQS](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html) object to use if you need to configure the client manually
-* `emptyQueueEvent` - _Boolean_ - If you want to know when the queue is empty active this flag (will emit an event). Default will not do
 
 ### `consumer.start()`
 
@@ -113,4 +112,4 @@ Each consumer is an [`EventEmitter`](http://nodejs.org/api/events.html) and emit
 |`message_received`|`message`|Fired when a message is received.|
 |`message_processed`|`message`|Fired when a message is successfully processed and removed from the queue.|
 |`stopped`|None|Fired when the consumer finally stops its work.|
-|`emptyQueue`|None|Fired when the queue is empty (All messages have been consumed).|
+|`empty`|None|Fired when the queue is empty (All messages have been consumed).|

--- a/index.js
+++ b/index.js
@@ -62,9 +62,6 @@ function Consumer(options) {
   this.waitTimeSeconds = options.waitTimeSeconds || 20;
   this.authenticationErrorTimeout = options.authenticationErrorTimeout || 10000;
 
-  this.emptyQueueEvent = options.emptyQueueEvent || false;
-  this.queueIsNotEmpty = true;
-
   this.sqs = options.sqs || new AWS.SQS({
     region: options.region || 'eu-west-1'
   });
@@ -130,16 +127,12 @@ Consumer.prototype._handleSqsResponse = function (err, response) {
   debug(response);
 
   if (response && response.Messages && response.Messages.length > 0) {
-    this.queueIsNotEmpty = true;
     async.each(response.Messages, this._processMessageBound, function () {
       // start polling again once all of the messages have been processed
       consumer._poll();
     });
   } else if (response && !response.Messages) {
-    if (this.emptyQueueEvent && this.queueIsNotEmpty) {
-      this.queueIsNotEmpty = false;
-      this.emit('emptyQueue');
-    }
+    this.emit('empty');
     this._poll();
   } else if (err && isAuthenticationError(err)) {
     // there was an authentication error, so wait a bit before repolling

--- a/test/index.js
+++ b/test/index.js
@@ -336,16 +336,7 @@ describe('Consumer', function () {
     it('fires a emptyQueue event when all messages have been consumed', function (done) {
       sqs.receiveMessage.yieldsAsync(null, {});
 
-      consumer = new Consumer({
-        queueUrl: 'some-queue-url',
-        region: 'some-region',
-        handleMessage: handleMessage,
-        sqs: sqs,
-        authenticationErrorTimeout: 20,
-        emptyQueueEvent: true
-      });
-
-      consumer.on('emptyQueue', function () {
+      consumer.on('empty', function () {
         done();
       });
 

--- a/test/index.js
+++ b/test/index.js
@@ -332,6 +332,25 @@ describe('Consumer', function () {
 
       consumer.start();
     });
+
+    it('fires a emptyQueue event when all messages have been consumed', function (done) {
+      sqs.receiveMessage.yieldsAsync(null, {});
+
+      consumer = new Consumer({
+        queueUrl: 'some-queue-url',
+        region: 'some-region',
+        handleMessage: handleMessage,
+        sqs: sqs,
+        authenticationErrorTimeout: 20,
+        emptyQueueEvent: true
+      });
+
+      consumer.on('emptyQueue', function () {
+        done();
+      });
+
+      consumer.start();
+    });
   });
 
   describe('.stop', function () {


### PR DESCRIPTION
Add empty queue event. When all messages have been consumed emit 'emptyQueue' and continues with the poll (you know when you can stop sqs consumer).

Include:
- Updated tests
- Updated documentation

