### PR TITLE
Add empty event

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,4 @@ Each consumer is an [`EventEmitter`](http://nodejs.org/api/events.html) and emit
 |`message_received`|`message`|Fired when a message is received.|
 |`message_processed`|`message`|Fired when a message is successfully processed and removed from the queue.|
 |`stopped`|None|Fired when the consumer finally stops its work.|
+|`empty`|None|Fired when the queue is empty (All messages have been consumed).|

--- a/index.js
+++ b/index.js
@@ -131,6 +131,9 @@ Consumer.prototype._handleSqsResponse = function (err, response) {
       // start polling again once all of the messages have been processed
       consumer._poll();
     });
+  } else if (response && !response.Messages) {
+    this.emit('empty');
+    this._poll();
   } else if (err && isAuthenticationError(err)) {
     // there was an authentication error, so wait a bit before repolling
     debug('There was an authentication error. Pausing before retrying.');

--- a/test/index.js
+++ b/test/index.js
@@ -332,6 +332,16 @@ describe('Consumer', function () {
 
       consumer.start();
     });
+
+    it('fires a emptyQueue event when all messages have been consumed', function (done) {
+      sqs.receiveMessage.yieldsAsync(null, {});
+
+      consumer.on('empty', function () {
+        done();
+      });
+
+      consumer.start();
+    });
   });
 
   describe('.stop', function () {


### PR DESCRIPTION
Add empty event. When all messages have been consumed emit 'empty' and continues with the poll.

Include:
   - Updated tests
   - Updated documentation

More info: [https://github.com/bbc/sqs-consumer/pull/49](url)