### PR TITLE
add `message` to parameter set of error events during message processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Each consumer is an [`EventEmitter`](http://nodejs.org/api/events.html) and emit
 
 |Event|Params|Description|
 |-----|------|-----------|
-|`error`|`err`|Fired when an error occurs interacting with the queue.|
-|`processing_error`|`err`|Fired when an error occurs processing the message.|
+|`error`|`err`, `message`|Fired when an error occurs interacting with the queue.|
+|`processing_error`|`err`, `message`|Fired when an error occurs processing the message.|
 |`message_received`|`message`|Fired when a message is received.|
 |`message_processed`|`message`|Fired when a message is successfully processed and removed from the queue.|
 |`stopped`|None|Fired when the consumer finally stops its work.|

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Each consumer is an [`EventEmitter`](http://nodejs.org/api/events.html) and emit
 
 |Event|Params|Description|
 |-----|------|-----------|
-|`error`|`err`, `message`|Fired when an error occurs interacting with the queue.|
+|`error`|`err`, `[message]`|Fired when an error occurs interacting with the queue. If the error correlates to a message, that error is included in Params|
 |`processing_error`|`err`, `message`|Fired when an error occurs processing the message.|
 |`message_received`|`message`|Fired when a message is received.|
 |`message_processed`|`message`|Fired when a message is successfully processed and removed from the queue.|

--- a/index.js
+++ b/index.js
@@ -158,9 +158,9 @@ Consumer.prototype._processMessage = function (message, cb) {
   ], function (err) {
     if (err) {
       if (err.name === SQSError.name) {
-        consumer.emit('error', err);
+        consumer.emit('error', err, message);
       } else {
-        consumer.emit('processing_error', err);
+        consumer.emit('processing_error', err, message);
       }
     } else {
       consumer.emit('message_processed', message);

--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,7 @@ describe('Consumer', function () {
     sqs.receiveMessage = sinon.stub().yieldsAsync(null, response);
     sqs.receiveMessage.onSecondCall().returns();
     sqs.deleteMessage = sinon.stub().yieldsAsync(null);
+    sqs._deleteMessage = sinon.stub().yieldsAsync(null);
     consumer = new Consumer({
       queueUrl: 'some-queue-url',
       region: 'some-region',
@@ -109,20 +110,35 @@ describe('Consumer', function () {
 
       consumer.on('error', function (err) {
         assert.ok(err);
-        assert.equal(err.message, 'SQS delete message failed: Delete error');
         done();
       });
 
       consumer.start();
     });
 
-    it('fires an error event when an error occurs processing a message', function (done) {
+    it('fires a `processing_error` event when a non-`SQSError` error occurs processing a message', function (done) {
       var processingErr = new Error('Processing error');
 
       handleMessage.yields(processingErr);
 
-      consumer.on('processing_error', function (err) {
+      consumer.on('processing_error', function (err, message) {
         assert.equal(err, processingErr);
+        assert.equal(message.MessageId, '123');
+        done();
+      });
+
+      consumer.start();
+    });
+
+    it('fires an `error` event when an `SQSError` occurs processing a message', function (done) {
+      var sqsError = new Error('Processing error');
+      sqsError.name = 'SQSError';
+
+      handleMessage.yields(sqsError);
+
+      consumer.on('error', function (err, message) {
+        assert.equal(err, sqsError);
+        assert.equal(message.MessageId, '123');
         done();
       });
 

--- a/test/index.js
+++ b/test/index.js
@@ -110,6 +110,7 @@ describe('Consumer', function () {
 
       consumer.on('error', function (err) {
         assert.ok(err);
+        assert.equal(err.message, 'SQS delete message failed: Delete error');
         done();
       });
 


### PR DESCRIPTION
feat(event): add `message` parameter to message processing error events

Added the `message` which correlates to a processing error to the following events:
- _processMessage->error
- _processMessage->processing_error 