### PR TITLE
Add support for concurrent polling when batchSize exceeds 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Creates a new SQS consumer.
 * `handleMessage` - _Function_ - A function to be called whenever a message is received. Receives an SQS message object as its first argument and a function to call when the message has been handled as its second argument (i.e. `handleMessage(message, done)`).
 * `attributeNames` - _Array_ - List of queue attributes to retrieve (i.e. `['All', 'ApproximateFirstReceiveTimestamp', 'ApproximateReceiveCount']`).
 * `messageAttributeNames` - _Array_ - List of message attributes to retrieve (i.e. `['name', 'address']`).
-* `batchSize` - _Number_ - The number of messages to request from SQS when polling (default `1`). This cannot be higher than the AWS limit of 10.
+* `batchSize` - _Number_ - The number of messages to request from SQS when polling (default `1`). Concurrent polling is used if this exceeds the AWS limit of 10.
 * `visibilityTimeout` - _Number_ - The duration (in seconds) that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request.
 * `waitTimeSeconds` - _Number_ - The duration (in seconds) for which the call will wait for a message to arrive in the queue before returning.
 * `authenticationErrorTimeout` - _Number_ - The duration (in milliseconds) to wait before retrying after an authentication error (defaults to `10000`).

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ var requiredOptions = [
     'handleMessage'
   ];
 
+  var MAX_NUM_MESSAGES = 10;
+
 /**
  * Construct a new SQSError
  */
@@ -27,8 +29,8 @@ function validate(options) {
     }
   });
 
-  if (options.batchSize > 10 || options.batchSize < 1) {
-    throw new Error('SQS batchSize option must be between 1 and 10.');
+  if (options.batchSize < 1) {
+    throw new Error('SQS batchSize option must be greater than 0.');
   }
 }
 
@@ -66,7 +68,6 @@ function Consumer(options) {
     region: options.region || process.env.AWS_REGION || 'eu-west-1'
   });
 
-  this._handleSqsResponseBound = this._handleSqsResponse.bind(this);
   this._processMessageBound = this._processMessage.bind(this);
 }
 
@@ -86,7 +87,17 @@ Consumer.prototype.start = function () {
   if (this.stopped) {
     debug('Starting consumer');
     this.stopped = false;
-    this._poll();
+
+    var numReceives = Math.floor(this.batchSize / MAX_NUM_MESSAGES);
+    var remainder = this.batchSize % MAX_NUM_MESSAGES;
+
+    for (var i = 0; i < numReceives; i++) {
+      this._poll(MAX_NUM_MESSAGES);
+    }
+
+    if (remainder) {
+      this._poll(remainder);
+    }
   }
 };
 
@@ -98,27 +109,31 @@ Consumer.prototype.stop = function () {
   this.stopped = true;
 };
 
-Consumer.prototype._poll = function () {
+Consumer.prototype._poll = function (batchSize) {
+  var consumer = this;
+
   var receiveParams = {
     QueueUrl: this.queueUrl,
     AttributeNames: this.attributeNames,
     MessageAttributeNames: this.messageAttributeNames,
-    MaxNumberOfMessages: this.batchSize,
+    MaxNumberOfMessages: batchSize,
     WaitTimeSeconds: this.waitTimeSeconds,
     VisibilityTimeout: this.visibilityTimeout
   };
 
   if (!this.stopped) {
     debug('Polling for messages');
-    this.sqs.receiveMessage(receiveParams, this._handleSqsResponseBound);
+    this.sqs.receiveMessage(receiveParams, function (err, response) {
+      consumer._handleSqsResponse(err, response, function () {
+        consumer._poll(batchSize);
+      });
+    });
   } else {
     this.emit('stopped');
   }
 };
 
-Consumer.prototype._handleSqsResponse = function (err, response) {
-  var consumer = this;
-
+Consumer.prototype._handleSqsResponse = function (err, response, cb) {
   if (err) {
     this.emit('error', new SQSError('SQS receive message failed: ' + err.message));
   }
@@ -127,20 +142,19 @@ Consumer.prototype._handleSqsResponse = function (err, response) {
   debug(response);
 
   if (response && response.Messages && response.Messages.length > 0) {
-    async.each(response.Messages, this._processMessageBound, function () {
-      // start polling again once all of the messages have been processed
-      consumer._poll();
+    async.each(response.Messages, this._processMessageBound, function() {
+      cb();
     });
   } else if (response && !response.Messages) {
     this.emit('empty');
-    this._poll();
+    cb();
   } else if (err && isAuthenticationError(err)) {
     // there was an authentication error, so wait a bit before repolling
     debug('There was an authentication error. Pausing before retrying.');
-    setTimeout(this._poll.bind(this), this.authenticationErrorTimeout);
+    setTimeout(cb, this.authenticationErrorTimeout);
   } else {
     // there were no messages, so start polling again
-    this._poll();
+    cb();
   }
 };
 


### PR DESCRIPTION
Some of my services need to consume messages more quickly than 10 messages at a time. As such, the services invoke multiple instances of `sqs-consumer`. Any time I need to do this for a service, I am forced to duplicate logic. Additionally, if more complex logic needs to occur around starting/stopping of a consumer, then that must be invoked for each instance. This same principle applies to listening to events from `sqs-consumer`

This PR adds functionality, such that `batchSize > 10`,  multiple calls to `_poll` will incur.

Thanks!