### PR TITLE
Keep messages alive and support multiple/priority queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ app.on('error', (err) => {
 app.start();
 ```
 
-* The queue is polled continuously for messages using [long polling](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html).
+* The queues are polled continuously for messages using [long polling](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html).
 * Messages are deleted from the queue once `done()` is called.
 * Calling `done(err)` with an error object will cause the message to be left on the queue. An [SQS redrive policy](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html) can be used to move messages that cannot be processed to a dead letter queue.
 * By default messages are processed one at a time – a new message won't be received until the first one has been processed. To process messages in parallel, use the `batchSize` option [detailed below](#options).
@@ -81,7 +81,7 @@ Creates a new SQS consumer.
 
 #### Options
 
-* `queueUrl` - _String_ - The SQS queue URL
+* `queueUrl` - _String_ - The SQS queue URL.  If an array is provided, the URLs will be cycled
 * `region` - _String_ - The AWS region (default `eu-west-1`)
 * `handleMessage` - _Function_ - A function to be called whenever a message is received. Receives an SQS message object as its first argument and a function to call when the message has been handled as its second argument (i.e. `handleMessage(message, done)`).
 * `attributeNames` - _Array_ - List of queue attributes to retrieve (i.e. `['All', 'ApproximateFirstReceiveTimestamp', 'ApproximateReceiveCount']`).
@@ -89,7 +89,8 @@ Creates a new SQS consumer.
 * `batchSize` - _Number_ - The number of messages to request from SQS when polling (default `1`). This cannot be higher than the AWS limit of 10.
 * `visibilityTimeout` - _Number_ - The duration (in seconds) that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request.
 * `terminateVisibilityTimeout` - _Boolean_ - If true, sets the message visibility timeout to 0 after a `processing_error` (defaults to `false`).
-* `waitTimeSeconds` - _Number_ - The duration (in seconds) for which the call will wait for a message to arrive in the queue before returning.
+* `waitTimeSeconds` - _Number_ - The duration (in seconds) for which the call will wait for a message to arrive in the queue before returning.  If more than one `queueUrl` is provided, you can provide an array here.  The duration will be applied to the matching `queueUrl`
+* `sticky` - _Array_ - If more than one `queueUrl` is provided, you can choose to have some queues "sticky".  This means that if it finds a message, it won't move on to the next queue for the next poll.  This is useful if you want to have a priority queue.
 * `authenticationErrorTimeout` - _Number_ - The duration (in milliseconds) to wait before retrying after an authentication error (defaults to `10000`).
 * `sqs` - _Object_ - An optional [AWS SQS](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html) object to use if you need to configure the client manually
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "sqs-consumer",
-  "version": "3.6.1",
+  "name": "sqs-priority-consumer",
+  "version": "3.7",
   "description": "Build SQS-based Node applications without the boilerplate",
   "main": "index.js",
   "scripts": {
@@ -12,18 +12,18 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/BBC/sqs-consumer.git"
+    "url": "https://github.com/jbreckman/sqs-priority-consumer.git"
   },
   "bugs": {
-    "url": "https://github.com/BBC/sqs-consumer/issues"
+    "url": "https://github.com/jbreckman/sqs-priority-consumer/issues"
   },
-  "homepage": "https://github.com/BBC/sqs-consumer",
+  "homepage": "https://github.com/jbreckman/sqs-priority-consumer",
   "keywords": [
     "sqs",
     "queue",
     "consumer"
   ],
-  "author": "robin@robinmurphy.co.uk",
+  "author": "jbreckman@gmail.com",
   "license": "MIT",
   "devDependencies": {
     "istanbul": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,11 @@
     "debug": "^2.1.0"
   },
   "jshintConfig": {
+    "browser": true,
     "quotmark": "single",
     "unused": true,
     "undef": true,
-    "node": true,
+    "esversion": 6,
     "globals": {
       "describe": false,
       "it": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-priority-consumer",
-  "version": "3.7",
+  "version": "3.7.0",
   "description": "Build SQS-based Node applications without the boilerplate",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "quotmark": "single",
     "unused": true,
     "undef": true,
+    "node": true,
     "esversion": 6,
     "globals": {
       "describe": false,

--- a/test/index.js
+++ b/test/index.js
@@ -127,7 +127,7 @@ describe('Consumer', function () {
     it('fires an error event when an error occurs deleting a message', function (done) {
       var deleteErr = new Error('Delete error');
 
-      handleMessage.yields(null);
+      //handleMessage.yields(null);
       sqs.deleteMessage.yields(deleteErr);
 
       consumer.on('error', function (err) {
@@ -276,7 +276,7 @@ describe('Consumer', function () {
       }, 10);
     });
 
-    it('doesn\'t consume more messages when called multiple times', function () {
+    it('doesn\'t consume more messages when called multiple times', function (done) {
       sqs.receiveMessage = sinon.stub().returns();
       consumer.start();
       consumer.start();
@@ -284,7 +284,10 @@ describe('Consumer', function () {
       consumer.start();
       consumer.start();
 
-      sinon.assert.calledOnce(sqs.receiveMessage);
+      setTimeout(function () {
+        sinon.assert.calledOnce(sqs.receiveMessage);
+        done();
+      }, 10);
     });
 
     it('consumes multiple messages when the batchSize is greater than 1', function (done) {
@@ -326,7 +329,7 @@ describe('Consumer', function () {
           MessageAttributeNames: ['attribute-1', 'attribute-2'],
           MaxNumberOfMessages: 3,
           WaitTimeSeconds: 20,
-          VisibilityTimeout: undefined
+          VisibilityTimeout: 30
         });
         sinon.assert.callCount(handleMessage, 3);
         done();
@@ -363,7 +366,7 @@ describe('Consumer', function () {
           MessageAttributeNames: [],
           MaxNumberOfMessages: 1,
           WaitTimeSeconds: 20,
-          VisibilityTimeout: undefined
+          VisibilityTimeout: 30
         });
         assert.equal(message, messageWithAttr);
         done();
@@ -448,7 +451,7 @@ describe('Consumer', function () {
       consumer.stop();
 
       setTimeout(function () {
-        sinon.assert.calledOnce(handleMessage);
+        sinon.assert.notCalled(handleMessage);
         done();
       }, 10);
     });

--- a/test/index.js
+++ b/test/index.js
@@ -408,7 +408,7 @@ describe('Consumer', function () {
       consumer.terminateVisibilityTimeout = false;
       consumer.on('processing_error', function () {
         setImmediate(function () {
-          sinon.assert.notCalled(sqs.changeMessageVisibility);
+          sinon.assert.calledOnce(sqs.changeMessageVisibility); // it's okay that it is called once to reset timeout by 30 seconds since the fetch timeout might be smaller
           done();
         });
       });
@@ -424,7 +424,7 @@ describe('Consumer', function () {
       sqs.changeMessageVisibility.yields(sqsError);
 
       consumer.terminateVisibilityTimeout = true;
-      consumer.on('error', function () {
+      consumer.on('error', function (err) {
         setImmediate(function () {
           sinon.assert.calledWith(sqs.changeMessageVisibility, {
             QueueUrl: 'some-queue-url',
@@ -450,7 +450,7 @@ describe('Consumer', function () {
         },
         sqs: sqs,
         authenticationErrorTimeout: 20,
-        visibilityTimeout: 2
+        visibilityTimeout: 3
       });
 
       consumer.start();
@@ -459,7 +459,7 @@ describe('Consumer', function () {
         sinon.assert.calledWith(sqs.changeMessageVisibility, {
           QueueUrl: 'some-queue-url',
           ReceiptHandle: 'receipt-handle',
-          VisibilityTimeout: 2
+          VisibilityTimeout: 3
         });
         sinon.assert.calledTwice(sqs.changeMessageVisibility);
         done();


### PR DESCRIPTION
Hi there,

This package was super helpful for us getting SQS off the ground, but I found that there were a couple of surprising gaps that we ran into.  This PR should fix most of them.

* It seems like this package is designed for messages that process very quickly (less than the visibility timeout of the poll).  This is not the case for us - our messages take anywhere from 30 seconds to 10 hours to process.  This will reset the visibility timeout as long as the message is being processed to prevent another consumer from starting to process the message.

* We wanted to have some messages have higher "priority" than others and be processed ahead of non-priority messages.  With this package as-is we could build a second queue, but would have to have dedicated consumers sitting and watching those priority messages.  Furthermore, if we had 5 regular consumers and 5 priority consumers, and suddenly had 100 high priority messages to process, it'd be a waste to let the 5 regular consumers sit and do nothing.  So I modified this to support multiple queue URLs which will be cycled.  You can have different timeouts per URL and can mark some URLs as "sticky"

Our configuration is currently as follows:

```
const app = Consumer.create({
      initialVisibilityTimeout: 10,
      queueUrl:         [data.PriorityUrl, data.QueueUrl],
      waitTimeSeconds:  [5, 20],
      sticky:           [true, false],
      handleMessage: (message, done) => { ... }
});
````

This polls the priority URL for 5 seconds, then the main URL for 20 seconds.  If it sees a message on the priority URL, it'll recheck the URL after processing that message.  If there is no priority message waiting, it'll wait for 5 seconds and then move onto the regular URL.  