### PR TITLE
Emit "response_processed" at the end of each response batch

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,6 +130,7 @@ Consumer.prototype._handleSqsResponse = function (err, response) {
   if (response && response.Messages && response.Messages.length > 0) {
     async.each(response.Messages, this._processMessageBound, function () {
       // start polling again once all of the messages have been processed
+      consumer.emit("response_processed");
       consumer._poll();
     });
   } else if (response && !response.Messages) {


### PR DESCRIPTION
Currently "message_processed" tells you when one message has been handled, but there is no way to see when one batch of messages is complete.

A common use case when streaming in many similar elements is to process one batchSize block of items then commit them all to the database at once, but with current sqs-consumer there is no event that is per batch.

This adds a "response_processed" event to be just like the "message_processed" event.  It does not emit the raw response object here, since it wasn't exposed before, I opted not to expose it.

