### PR TITLE
throw original error + stack trace

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -192,7 +192,8 @@ class Consumer extends EventEmitter {
     try {
       await this.handleMessage(message);
     } catch (err) {
-      throw new Error('Unexpected message handler failure: ' + err.message);
+      err.message = `Unexpected message handler failure: ${err.message}`;
+      throw err;
     }
   }
 }


### PR DESCRIPTION
When an error is thrown from the _executeHandler, the original stack trace is replaces with the new error's stack trace
This fix will ensure the original stack trace is emitted from the sqs-consumer