### PR TITLE
Added support to continuously extend the visibility timeout until the message is processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Creates a new SQS consumer.
 * `messageAttributeNames` - _Array_ - List of message attributes to retrieve (i.e. `['name', 'address']`).
 * `batchSize` - _Number_ - The number of messages to request from SQS when polling (default `1`). This cannot be higher than the AWS limit of 10.
 * `visibilityTimeout` - _Number_ - The duration (in seconds) that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request.
+* `extendVisibilityTimeout` - _Boolean_ - If true, will continuously extend the visibility timeout of a message until the callback is called, or the AWS limit of 12 hours is reached. (defaults to `false`).
 * `terminateVisibilityTimeout` - _Boolean_ - If true, sets the message visibility timeout to 0 after a `processing_error` (defaults to `false`).
 * `waitTimeSeconds` - _Number_ - The duration (in seconds) for which the call will wait for a message to arrive in the queue before returning.
 * `authenticationErrorTimeout` - _Number_ - The duration (in milliseconds) to wait before retrying after an authentication error (defaults to `10000`).

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -64,6 +64,7 @@ class Consumer extends EventEmitter {
     this.messageAttributeNames = options.messageAttributeNames || [];
     this.stopped = true;
     this.batchSize = options.batchSize || 1;
+    this.visibilityTimeout = options.visibilityTimeout || undefined;
     this.terminateVisibilityTimeout = options.terminateVisibilityTimeout || false;
     this.extendVisibilityTimeout = options.extendVisibilityTimeout || false;
     this.waitTimeSeconds = options.waitTimeSeconds || 20;
@@ -117,8 +118,10 @@ class Consumer extends EventEmitter {
         AttributeNames: ['VisibilityTimeout']
       };
 
-      const visTimeoutResponse = await this.sqs.getQueueAttributes(visTimeoutParams).promise();
-      this.visibilityTimeout = visTimeoutResponse['Attributes']['VisibilityTimeout'];
+      if (!this.visibilityTimeout) {
+        const visTimeoutResponse = await this.sqs.getQueueAttributes(visTimeoutParams).promise();
+        this.visibilityTimeout = visTimeoutResponse['Attributes']['VisibilityTimeout'];
+      }
 
       this._handleSqsResponse(response);
 

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -244,8 +244,10 @@ class Consumer extends EventEmitter {
           this.handleMessage(message),
           pending
         ]);
+        message.finishedProcessing = true;
       } else {
         await this.handleMessage(message);
+        message.finishedProcessing = true;
       }
     } catch (err) {
       if (err instanceof TimeoutError) {

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -61,8 +61,8 @@ class Consumer extends EventEmitter {
     this.messageAttributeNames = options.messageAttributeNames || [];
     this.stopped = true;
     this.batchSize = options.batchSize || 1;
-    this.visibilityTimeout = options.visibilityTimeout;
     this.terminateVisibilityTimeout = options.terminateVisibilityTimeout || false;
+    this.extendVisibilityTimeout = options.extendVisibilityTimeout || false;
     this.waitTimeSeconds = options.waitTimeSeconds || 20;
     this.authenticationErrorTimeout = options.authenticationErrorTimeout || 10000;
 
@@ -108,6 +108,15 @@ class Consumer extends EventEmitter {
       };
 
       const response = await this._receiveMessage(receiveParams);
+
+      const visTimeoutParams = {
+        QueueUrl: this.queueUrl,
+        AttributeNames: ['VisibilityTimeout']
+      };
+
+      const visTimeoutResponse = await this.sqs.getQueueAttributes(visTimeoutParams).promise();
+      this.visibilityTimeout = visTimeoutResponse['Attributes']['VisibilityTimeout'];
+
       this._handleSqsResponse(response);
 
     } catch (err) {
@@ -192,11 +201,37 @@ class Consumer extends EventEmitter {
     }
   }
 
+  extendTimeout(message) {
+    if (message.finishedProcessing !== true) {
+      message.visibilityTimeout = (message.visibilityTimeout * 2);
+      const boundExtendTimeout = this.extendTimeout.bind(this, message);
+      this.sqs
+        .changeMessageVisibility({
+          QueueUrl: this.queueUrl,
+          ReceiptHandle: message.ReceiptHandle,
+          VisibilityTimeout: message.visibilityTimeout
+        }).promise().then((err) => {
+          if (err) {
+            debug(err);
+          }
+          setTimeout(boundExtendTimeout, (message.visibilityTimeout * 450));
+        });
+    }
+  }
+
   async _executeHandler(message) {
     try {
+      message.finishedProcessing = false;
+      message.visibilityTimeout = this.visibilityTimeout;
+      if (this.extendVisibilityTimeout) {
+        const boundExtendTimeout = this.extendTimeout.bind(this, message);
+        boundExtendTimeout();
+      }
       await this.handleMessage(message);
+      message.finishedProcessing = true;
     } catch (err) {
       err.message = `Unexpected message handler failure: ${err.message}`;
+      message.finishedProcessing = true;
       throw err;
     }
   }

--- a/test/consumer.js
+++ b/test/consumer.js
@@ -476,7 +476,7 @@ describe('Consumer', () => {
       sandbox.assert.calledWith(sqs.changeMessageVisibility, {
         QueueUrl: 'some-queue-url',
         ReceiptHandle: 'receipt-handle',
-        VisibilityTimeout: 10
+        VisibilityTimeout: 2
       });
 
     });


### PR DESCRIPTION
Added an option to be passed into the consumer, called `extendVisibilityTimeout`, which is by default set to false. If enabled, the consumer will continuously extend the visibility timeout of any message that is being processed. Once handleMessage() is done executing, a flag is set in the message itself which prevents any asynchronous operations from extending the message out further.

All unit tests pass, added one to test this functionality, and it was tested with:

```const Consumer = require('./index.js');
var sleep = require('system-sleep');

const app = Consumer.create({
    queueUrl: 'https://sqs.us-east-1.amazonaws.com/0000000000000/canberktest',
    batchSize: 3,
    terminateVisibilityTimeout: true,
    region: 'us-east-1',
    extendVisibilityTimeout: true,
    handleMessage: (sqsMessage, done) => {
    console.log(sqsMessage)
    sleep(1000000)
  }
});

app.on('error', (err) => {
  console.error(err.message);
});

app.on('processing_error', (err) => {
  console.error(err.message);
});

app.start();