### PR TITLE
fix: Set consumer.stopped to true if polling is interrupted by an error

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -268,6 +268,9 @@ export class Consumer extends EventEmitter {
         if (isAuthenticationError(err)) {
           debug('There was an authentication error. Pausing before retrying.');
           setTimeout(this.poll, this.authenticationErrorTimeout);
+        } else {
+          debug('Stopped consumer due to polling error.')
+          this.stopped = true;
         }
         return;
       });

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -264,14 +264,14 @@ export class Consumer extends EventEmitter {
         this.poll();
       })
       .catch((err) => {
-        this.emit('error', err);
         if (isAuthenticationError(err)) {
           debug('There was an authentication error. Pausing before retrying.');
           setTimeout(this.poll, this.authenticationErrorTimeout);
         } else {
-          debug('Stopped consumer due to polling error.')
+          debug('Stopped consumer due to polling error.');
           this.stopped = true;
         }
+        this.emit('error', err);
         return;
       });
   }

--- a/test/consumer.ts
+++ b/test/consumer.ts
@@ -288,6 +288,25 @@ describe('Consumer', () => {
       });
     });
 
+    it('waits before repolling when a 403 error occurs', async () => {
+      const invalidSignatureErr = {
+        statusCode: 503,
+        message: 'Service Unavailable'
+      };
+      sqs.receiveMessage = stubReject(invalidSignatureErr);
+
+      return new Promise((resolve) => {
+        const errorListener = sandbox.stub();
+        errorListener.onFirstCall().callsFake(() => {
+          assert.equal(consumer.stopped, true);
+          resolve();
+        });
+
+        consumer.on('error', errorListener);
+        consumer.start();
+      });
+    });
+
     it('fires a message_received event when a message is received', async () => {
       consumer.start();
       const message = await pEvent(consumer, 'message_received');

--- a/test/consumer.ts
+++ b/test/consumer.ts
@@ -288,7 +288,7 @@ describe('Consumer', () => {
       });
     });
 
-    it('waits before repolling when a 403 error occurs', async () => {
+    it('accurately sets consumer.stopped to true after failing due to an unhandled error', async () => {
       const invalidSignatureErr = {
         statusCode: 503,
         message: 'Service Unavailable'


### PR DESCRIPTION
This feature is necessary to allow to support automated Health Checks on SQS Consumers. If the `stopped` flag accurately represents the status of the SQS consumer, its healthiness can be read, monitored and exposed.

# Current Behavior
In the current implementation polling will only continue after an error if the error itself was a AuthenticationError. For all other errors it will silently stop pulling without properly updating its `stopped` property.

# Expected Behavior 
The `stopped` flag should always represent the accurate polling status. If it is not polling I expect it to be set to false.