### PR TITLE
feat: Expose Polling Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Start polling the queue for messages.
 
 Stop polling the queue for messages.
 
+### `consumer.isRunning`  
+
+Returns the current polling state of the consumer: `true` if it is actively polling, `false` if it is not.
+
 ### Events
 
 Each consumer is an [`EventEmitter`](http://nodejs.org/api/events.html) and emits the following events:

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -120,7 +120,7 @@ export class Consumer extends EventEmitter {
   }
 
   public get isRunning(): boolean {
-      return this.stopped !== true;
+      return !this.stopped;
   }
 
   public static create(options: ConsumerOptions): Consumer {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -119,6 +119,10 @@ export class Consumer extends EventEmitter {
     autoBind(this);
   }
 
+  public get isRunning(): boolean {
+      return this.stopped !== true;
+  }
+
   public static create(options: ConsumerOptions): Consumer {
     return new Consumer(options);
   }

--- a/test/consumer.ts
+++ b/test/consumer.ts
@@ -586,4 +586,18 @@ describe('Consumer', () => {
       });
     });
   });
+
+  describe('isRunning', async () => {
+    it('returns true if the consumer is polling', () => {
+      consumer.start();
+      assert.isTrue(consumer.isRunning);
+      consumer.stop();
+    });
+
+    it('returns false if the consumer is not polling', () => {
+      consumer.start();
+      consumer.stop();
+      assert.isFalse(consumer.isRunning);
+    });
+  });
 });


### PR DESCRIPTION
Since `Consumer.stopped` is a private member of the Consumer, it is right now not possible to check if it's running or not from the outside.

In order to see from the outside if the polling has correctly started, I propose exposing the boolean through a getter `isRunning`.