### PR TITLE
fix: 🐛 es modules can no longer use require

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,12 @@
       "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
       "dev": true
     },
+    "@types/debug": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.3.tgz",
+      "integrity": "sha512-PQverGatRgqIhRLracrC8k/j5A6QOASVLR0wuURx6ROQZx3OQ9PnTc/5Xrznny/xaO0TwdxSgGyG90NCzk37Rg==",
+      "dev": true
+    },
     "@types/mocha": {
       "version": "2.2.48",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",

--- a/package.json
+++ b/package.json
@@ -33,21 +33,22 @@
   "devDependencies": {
     "@types/aws-sdk": "^2.7.0",
     "@types/chai": "^4.1.4",
+    "@types/debug": "^4.1.3",
     "@types/mocha": "^2.2.43",
     "@types/node": "^10.12.18",
     "@types/sinon": "^4.0.0",
     "@types/typescript": "^2.0.0",
     "chai": "^4.2.0",
-    "ts-node": "^3.3.0",
-    "tslint": "^5.12.1",
-    "tslint-config-airbnb": "^5.3.1",
-    "tslint-microsoft-contrib": "^5.0.3",
-    "typescript": "^2.6.1",
     "codeclimate-test-reporter": "^0.5.1",
     "mocha": "^5.2.0",
     "nyc": "^13.1.0",
     "p-event": "^2.1.0",
-    "sinon": "^7.2.2"
+    "sinon": "^7.2.2",
+    "ts-node": "^3.3.0",
+    "tslint": "^5.12.1",
+    "tslint-config-airbnb": "^5.3.1",
+    "tslint-microsoft-contrib": "^5.0.3",
+    "typescript": "^2.6.1"
   },
   "dependencies": {
     "aws-sdk": "^2.393.0",


### PR DESCRIPTION
Latest version of ts-jest will throw an error when an ES module uses require.

Issues: #159

Keeping to your linting style, that the import name has to be the same as the module name, the variable `debug` had to be renamed.