### PR TITLE
Fix queueUrl type to be consistent with requiredOptions

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -70,7 +70,7 @@ function hasMessages(response: ReceieveMessageResponse): boolean {
 }
 
 export interface ConsumerOptions {
-  queueUrl?: string;
+  queueUrl: string;
   attributeNames?: string[];
   messageAttributeNames?: string[];
   stopped?: boolean;


### PR DESCRIPTION
Was using the ConsumerOptions type and noticed that the queueUrl as marked as optional, which does not seem consistent with what is in the requiredOptions.