### PR TITLE
fix: terminateVisibilityTimeout function name

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -179,7 +179,7 @@ export class Consumer extends EventEmitter {
 
       if (this.terminateVisibilityTimeout) {
         try {
-          await this.terminateVisabilityTimeout(message);
+          await this.terminateVisibilityTimeout(message);
         } catch (err) {
           this.emit('error', err, message);
         }
@@ -239,7 +239,7 @@ export class Consumer extends EventEmitter {
     }
   }
 
-  private async terminateVisabilityTimeout(message: SQSMessage): Promise<PromiseResult<any, AWSError>> {
+  private async terminateVisibilityTimeout(message: SQSMessage): Promise<PromiseResult<any, AWSError>> {
     return this.sqs
       .changeMessageVisibility({
         QueueUrl: this.queueUrl,

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -308,7 +308,7 @@ export class Consumer extends EventEmitter {
 
       if (this.terminateVisibilityTimeout) {
         try {
-          await this.terminateVisabilityTimeoutBatch(messages);
+          await this.terminateVisibilityTimeoutBatch(messages);
         } catch (err) {
           this.emit('error', err, messages);
         }
@@ -345,7 +345,7 @@ export class Consumer extends EventEmitter {
     }
   }
 
-  private async terminateVisabilityTimeoutBatch(messages: SQSMessage[]): Promise<PromiseResult<any, AWSError>> {
+  private async terminateVisibilityTimeoutBatch(messages: SQSMessage[]): Promise<PromiseResult<any, AWSError>> {
     const params = {
       QueueUrl: this.queueUrl,
       Entries: messages.map((message) => ({


### PR DESCRIPTION
Currently the function is called `terminateVisabilityTimeout` but the correct is `terminateVisibilityTimeout`.

A small spelling mistake.

In **README.md** it's already `terminateVisibilityTimeout`.