### PR TITLE
Revert "fix: terminateVisibilityTimeout function name"

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -179,7 +179,7 @@ export class Consumer extends EventEmitter {
 
       if (this.terminateVisibilityTimeout) {
         try {
-          await this.terminateVisibilityTimeout(message);
+          await this.terminateVisabilityTimeout(message);
         } catch (err) {
           this.emit('error', err, message);
         }
@@ -239,7 +239,7 @@ export class Consumer extends EventEmitter {
     }
   }
 
-  private async terminateVisibilityTimeout(message: SQSMessage): Promise<PromiseResult<any, AWSError>> {
+  private async terminateVisabilityTimeout(message: SQSMessage): Promise<PromiseResult<any, AWSError>> {
     return this.sqs
       .changeMessageVisibility({
         QueueUrl: this.queueUrl,
@@ -308,7 +308,7 @@ export class Consumer extends EventEmitter {
 
       if (this.terminateVisibilityTimeout) {
         try {
-          await this.terminateVisibilityTimeoutBatch(messages);
+          await this.terminateVisabilityTimeoutBatch(messages);
         } catch (err) {
           this.emit('error', err, messages);
         }
@@ -345,7 +345,7 @@ export class Consumer extends EventEmitter {
     }
   }
 
-  private async terminateVisibilityTimeoutBatch(messages: SQSMessage[]): Promise<PromiseResult<any, AWSError>> {
+  private async terminateVisabilityTimeoutBatch(messages: SQSMessage[]): Promise<PromiseResult<any, AWSError>> {
     const params = {
       QueueUrl: this.queueUrl,
       Entries: messages.map((message) => ({


### PR DESCRIPTION
Function name can't be updated because 'terminateVisibilityTimeout' is defined already as a private property.

Reverts bbc/sqs-consumer#209