### PR TITLE
feat: export SQS Message type

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -9,8 +9,8 @@ import { SQSError, TimeoutError } from './errors';
 const debug = Debug('sqs-consumer');
 
 type ReceieveMessageResponse = PromiseResult<SQS.Types.ReceiveMessageResult, AWSError>;
-type SQSMessage = SQS.Types.Message;
 type ReceiveMessageRequest = SQS.Types.ReceiveMessageRequest;
+export type SQSMessage = SQS.Types.Message;
 
 const requiredOptions = [
   'queueUrl',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { Consumer, ConsumerOptions } from './consumer';
+export { SQSMessage, Consumer, ConsumerOptions } from './consumer';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Export the `SQSMessage` type that comes from the AWS SDK.

## Motivation and Context

When importing sqs-consumer in TypeScript code, it's useful to be able to create functions that are explicitly typed as receiving parameters of type `SQSMessage`. At the moment this requires importing the type directly from the aws-sdk, but my project has no other dependency on the aws-sdk. It would therefore be useful to be able to import it from the `sqs-consumer` package.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I do not think this change requires any new test cases.