### PR TITLE
Automatically extend message visibility timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Creates a new SQS consumer.
 * `messageAttributeNames` - _Array_ - List of message attributes to retrieve (i.e. `['name', 'address']`).
 * `batchSize` - _Number_ - The number of messages to request from SQS when polling (default `1`). This cannot be higher than the AWS limit of 10.
 * `visibilityTimeout` - _Number_ - The duration (in seconds) that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request.
+* `heartbeatInterval` - _Number_ - The interval (in seconds) between requests to extend the message visibility timeout. On each heartbeat the visibility is extended by adding `visibilityTimeout` to the number of seconds since the start of the handler function. This value must less than `visibilityTimeout`.
 * `terminateVisibilityTimeout` - _Boolean_ - If true, sets the message visibility timeout to 0 after a `processing_error` (defaults to `false`).
 * `waitTimeSeconds` - _Number_ - The duration (in seconds) for which the call will wait for a message to arrive in the queue before returning.
 * `authenticationErrorTimeout` - _Number_ - The duration (in milliseconds) to wait before retrying after an authentication error (defaults to `10000`).


### PR DESCRIPTION
## Description

This adds a new config property called `heartbeatInteval` that can be used in conjunction with `visibilityTimeout` to automatically extend the visibility timeout of a (batch of) message(s). Example behaviour with `visibilityTimeout=40` and `heartbeatInteval=30`:
- a message is retrieved from queue with visibility timeout set to 40 seconds that will take 75 seconds to process 
- after 30 seconds the visibility timeout is set to 70 seconds
- after 60 seconds the visibility timeout is set to 100 seconds
- after 75 seconds the processing completes and no further extensions are made to the visibility timeout for that message

Setting `heartbeatInteval` without also setting `visibilityTimeout` results in an error being thrown at startup. `heartbeatInteval >= visibilityTimeout` also results in an error being thrown.
## Motivation and Context

This PR addresses https://github.com/bbc/sqs-consumer/issues/218. This will probably be easiest to review by looking at each commit separately. All tests pass for each commit.

- The first commit changes the tests to use Sinon fake timers. This makes the tests run a little faster, but the main motivation was to simplify writing new tests for the heartbeat functionality.
- The second commit refactors the methods that call `changeMessageVisibility` so that the timeout is passed in as an argument rather than being hard coded to `0`. Some of the error handling was also moved into these methods so it wouldn't be duplicated later.
- The third commit adds all of the functional changes and new tests for the `heartbeatInteval` feature.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
