### PR TITLE
fix: allow ConsumerOptions of type number to be zero

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -127,9 +127,9 @@ export class Consumer extends EventEmitter {
     this.batchSize = options.batchSize || 1;
     this.visibilityTimeout = options.visibilityTimeout;
     this.terminateVisibilityTimeout = options.terminateVisibilityTimeout || false;
-    this.waitTimeSeconds = options.waitTimeSeconds || 20;
-    this.authenticationErrorTimeout = options.authenticationErrorTimeout || 10000;
-    this.pollingWaitTimeMs = options.pollingWaitTimeMs || 0;
+    this.waitTimeSeconds = options.waitTimeSeconds ?? 20;
+    this.authenticationErrorTimeout = options.authenticationErrorTimeout ?? 10000;
+    this.pollingWaitTimeMs = options.pollingWaitTimeMs ?? 0;
 
     this.sqs = options.sqs || new SQS({
       region: options.region || process.env.AWS_REGION || 'eu-west-1'


### PR DESCRIPTION

## Description
Fixes: #223 

Uses nullish coalescing introduced in Typescript 3.7: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing

Nullish coalescing is not applied to `batchSize` as zero is not a reasonable value for `batchSize`.

## Motivation and Context
#223 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
