### PR TITLE
Fix TypeError when handler throws not standard error.

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -264,7 +264,7 @@ export class Consumer extends EventEmitter {
     } catch (err) {
       if (err instanceof TimeoutError) {
         err.message = `Message handler timed out after ${this.handleMessageTimeout}ms: Operation timed out.`;
-      } else {
+      } else if (err instanceof Error) {
         err.message = `Unexpected message handler failure: ${err.message}`;
       }
       throw err;


### PR DESCRIPTION
Fix TypeError when handler throws not standard error.

## Description
The error can be from any type:
```
throw {};
throw 'a';
throw undefined;
```
Are valid

Currently, we try to set message property to the error value, which causes this error:
```
throw 'a';
....
....
{
   "message":"TypeError: Cannot create property 'message' on string 'a'",
   "stack":"TypeError: Cannot create property 'message' on string 'a'\n    at Consumer.executeHandler (/src/node_modules/sqs-consumer/dist/consumer.js:175:29)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)"
}
```

## Motivation and Context
Fix an error as explained above.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
