### PR TITLE
Allow use of a semaphore in order to control how much poll is called.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Creates a new SQS consumer.
 * `region` - _String_ - The AWS region (default `eu-west-1`)
 * `handleMessage` - _Function_ - An `async` function (or function that returns a `Promise`) to be called whenever a message is received. Receives an SQS message object as it's first argument.
 * `handleMessageBatch` - _Function_ - An `async` function (or function that returns a `Promise`) to be called whenever a batch of messages is received. Similar to `handleMessage` but will receive the list of messages, not each message individually. **If both are set, `handleMessageBatch` overrides `handleMessage`**.
+* `handleSemaphore` - _Function_ - An `async` function (or function that returns a `Promise`) that wait a condition to poll new messages from sqs. It can call a acquire semaphore function that could be released after the message be processed. It let to control how fast messages are consumed from sqs.
 * `handleMessageTimeout` - _Number_ - Time in ms to wait for `handleMessage` to process a message before timing out. Emits `timeout_error` on timeout. By default, if `handleMessage` times out, the unprocessed message returns to the end of the queue.
 * `attributeNames` - _Array_ - List of queue attributes to retrieve (i.e. `['All', 'ApproximateFirstReceiveTimestamp', 'ApproximateReceiveCount']`).
 * `messageAttributeNames` - _Array_ - List of message attributes to retrieve (i.e. `['name', 'address']`).


### PR DESCRIPTION
## Description

It let you pass a async function or function that return a promise to await a semaphore before calling the setTimeout function to poll new messages.

It intend to let consume a lot of messages without to wait handling each one, but
limit who much are processed in parallel.

## Motivation and Context

I would like to consume messages faster with a global or local semaphore. Currently the pool waits the handling function to receive new messages, but theses changes let the library user to control it better.

The library behavior is not changed if semaphoreHandle is not passed into the options, so it's retrocompatible.

It solve the problem of consuming many messages in parallel with a slow message handling function.

## Types of changes
New feature (non-breaking change which adds functionality)

