### PR TITLE
Call handleMessage in sequence, instead of using Promise.all()

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -188,7 +188,10 @@ export class Consumer extends EventEmitter {
           // prefer handling messages in batch when available
           await this.processMessageBatch(response.Messages);
         } else {
-          await Promise.all(response.Messages.map(this.processMessage));
+          // handle messages in sequence to preserve ordering
+          for (const message of response.Messages) {
+            await this.processMessage(message);
+          }
         }
         this.emit('response_processed');
       } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
I removed `await Promise.all()` in favor of `for (...) { await }`, because Promise.all could result in messages not being handled in order.

## Motivation and Context
Message ordering is important. The same can be said about the order in which messages are processed. In many cases, if not most, messages need to be processed one after the other, in the order they arrive.

Promise.all() runs handlers for all messages "in parallel". Well, in fact, it's in sequence until the first `await` in the handler's code. However, since handleMessage is [declared to be an async function](https://github.com/bbc/sqs-consumer/blob/3cafbb7e2b4847e3afbd6ebb3cc17bbc6faceb09/src/consumer.ts#L91), I presume it will usually have an `await`. In practice, that means that messages are not processed in sequence, waiting for the previous message to be finished, but all at once.

My code fixes the issue by eliminating the parallelism and instead introducing a for loop in which we await the completion of each message handler before continuing.

This keeps the order in which handleMessage is called, but it changes the order of when it finishes. It is therefore potentially a breaking change. 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
