### PR TITLE
add deleteMessagesOnSuccess option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ app.start();
 ```
 
 * The queue is polled continuously for messages using [long polling](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html).
-* Messages are deleted from the queue once the handler function has completed successfully.
+* By default, messages are deleted from the queue once the handler function has completed successfully. To keep messages in the queue, use the `deleteMessagesOnSuccess` option [detailed below](#options)
 * Throwing an error (or returning a rejected promise) from the handler function will cause the message to be left on the queue. An [SQS redrive policy](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html) can be used to move messages that cannot be processed to a dead letter queue.
 * By default messages are processed one at a time – a new message won't be received until the first one has been processed. To process messages in parallel, use the `batchSize` option [detailed below](#options).
 * By default, the default Node.js HTTP/HTTPS SQS agent creates a new TCP connection for every new request ([AWS SQS documentation](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html)). To avoid the cost of establishing a new connection, you can reuse an existing connection by passing a new SQS instance with `keepAlive: true`.
@@ -138,6 +138,7 @@ Creates a new SQS consumer.
 * `authenticationErrorTimeout` - _Number_ - The duration (in milliseconds) to wait before retrying after an authentication error (defaults to `10000`).
 * `pollingWaitTimeMs` - _Number_ - The duration (in milliseconds) to wait before repolling the queue (defaults to `0`).
 * `sqs` - _Object_ - An optional [AWS SQS](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html) object to use if you need to configure the client manually
+* `deleteMessagesOnSuccess` - _Boolean_ - Determine if messages are deleted from the queue once the handler function has completed successfully (defaults to `true`)
 
 ### `consumer.start()`
 

--- a/test/consumer.ts
+++ b/test/consumer.ts
@@ -390,6 +390,25 @@ describe('Consumer', () => {
       sandbox.assert.notCalled(sqs.deleteMessage);
     });
 
+    it('doesn\'t delete the message when the option deleteMessagesOnSuccess is set to false', async () => {
+      consumer = new Consumer({
+        queueUrl: 'some-queue-url',
+        region: 'some-region',
+        handleMessage,
+        sqs,
+        authenticationErrorTimeout: 20,
+        deleteMessagesOnSuccess: false
+      });
+
+      handleMessage.resolves();
+
+      consumer.start();
+      await pEvent(consumer, 'message_processed');
+      consumer.stop();
+
+      sandbox.assert.notCalled(sqs.deleteMessage);
+    });
+
     it('consumes another message once one is processed', async () => {
       handleMessage.resolves();
 


### PR DESCRIPTION
Add deleteMessagesOnSuccess option to 

## Description
add `deleteMessagesOnSuccess` option to prevent the "delete messages when handler function completes without errors" default behavior.

## Motivation and Context
The maximum batch size for batch operations is 10 messages (sqs hard limit).
Let's assume that we have an operation that needs to aggregate 1000 messages to work properly: deleting messages in groups of 10 while we are recovering them could lay to the loss of those messages if the final operation fails; in fact, the moment when I will delete all 1000 messages is at the end of the operation not after the completion of the handleMessageBatch function.

Adding the `deleteMessagesOnSuccess` option I can manually handle the deletion of the messages.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
