### PR TITLE
Issue #269 - fix the call to ChangeVisibilityTimeout to not include elapsed seconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-consumer",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "Build SQS-based Node applications without the boilerplate",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -203,8 +203,8 @@ export class Consumer extends EventEmitter {
     let heartbeat;
     try {
       if (this.heartbeatInterval) {
-        heartbeat = this.startHeartbeat(async (elapsedSeconds) => {
-          return this.changeVisabilityTimeout(message, elapsedSeconds + this.visibilityTimeout);
+        heartbeat = this.startHeartbeat(async () => {
+          return this.changeVisabilityTimeout(message, this.visibilityTimeout);
         });
       }
       await this.executeHandler(message);
@@ -338,8 +338,8 @@ export class Consumer extends EventEmitter {
     let heartbeat;
     try {
       if (this.heartbeatInterval) {
-        heartbeat = this.startHeartbeat(async (elapsedSeconds) => {
-          return this.changeVisabilityTimeoutBatch(messages, elapsedSeconds + this.visibilityTimeout);
+        heartbeat = this.startHeartbeat(async () => {
+          return this.changeVisabilityTimeoutBatch(messages, this.visibilityTimeout);
         });
       }
       await this.executeBatchHandler(messages);
@@ -405,11 +405,9 @@ export class Consumer extends EventEmitter {
     }
   }
 
-  private startHeartbeat(heartbeatFn: (elapsedSeconds: number) => void): NodeJS.Timeout {
-    const startTime = Date.now();
+  private startHeartbeat(heartbeatFn: () => void): NodeJS.Timeout {
     return setInterval(() => {
-      const elapsedSeconds = Math.ceil((Date.now() - startTime) / 1000);
-      heartbeatFn(elapsedSeconds);
+      heartbeatFn();
     }, this.heartbeatInterval * 1000);
   }
 }

--- a/test/consumer.ts
+++ b/test/consumer.ts
@@ -623,7 +623,7 @@ describe('Consumer', () => {
 
     });
 
-    it('extends visibility timeout for long running handler functions', async () => {
+    it('uses the correct visibility timeout for long running handler functions', async () => {
       consumer = new Consumer({
         queueUrl: 'some-queue-url',
         region: 'some-region',
@@ -641,17 +641,17 @@ describe('Consumer', () => {
       sandbox.assert.calledWith(sqs.changeMessageVisibility, {
         QueueUrl: 'some-queue-url',
         ReceiptHandle: 'receipt-handle',
-        VisibilityTimeout: 70
+        VisibilityTimeout: 40
       });
       sandbox.assert.calledWith(sqs.changeMessageVisibility, {
         QueueUrl: 'some-queue-url',
         ReceiptHandle: 'receipt-handle',
-        VisibilityTimeout: 100
+        VisibilityTimeout: 40
       });
       sandbox.assert.calledOnce(clearIntervalSpy);
     });
 
-    it('extends visibility timeout for long running batch handler functions', async () => {
+    it('passes in the correct visibility timeout for long running batch handler functions', async () => {
       sqs.receiveMessage = stubResolve({
         Messages: [
           { MessageId: '1', ReceiptHandle: 'receipt-handle-1', Body: 'body-1' },
@@ -677,17 +677,17 @@ describe('Consumer', () => {
       sandbox.assert.calledWith(sqs.changeMessageVisibilityBatch, {
         QueueUrl: 'some-queue-url',
         Entries: [
-          { Id: '1', ReceiptHandle: 'receipt-handle-1', VisibilityTimeout: 70 },
-          { Id: '2', ReceiptHandle: 'receipt-handle-2', VisibilityTimeout: 70 },
-          { Id: '3', ReceiptHandle: 'receipt-handle-3', VisibilityTimeout: 70 }
+          { Id: '1', ReceiptHandle: 'receipt-handle-1', VisibilityTimeout: 40 },
+          { Id: '2', ReceiptHandle: 'receipt-handle-2', VisibilityTimeout: 40 },
+          { Id: '3', ReceiptHandle: 'receipt-handle-3', VisibilityTimeout: 40 }
         ]
       });
       sandbox.assert.calledWith(sqs.changeMessageVisibilityBatch, {
         QueueUrl: 'some-queue-url',
         Entries: [
-          { Id: '1', ReceiptHandle: 'receipt-handle-1', VisibilityTimeout: 100 },
-          { Id: '2', ReceiptHandle: 'receipt-handle-2', VisibilityTimeout: 100 },
-          { Id: '3', ReceiptHandle: 'receipt-handle-3', VisibilityTimeout: 100 }
+          { Id: '1', ReceiptHandle: 'receipt-handle-1', VisibilityTimeout: 40 },
+          { Id: '2', ReceiptHandle: 'receipt-handle-2', VisibilityTimeout: 40 },
+          { Id: '3', ReceiptHandle: 'receipt-handle-3', VisibilityTimeout: 40 }
         ]
       });
       sandbox.assert.calledOnce(clearIntervalSpy);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Basically, the code in `consumer.ts` in `processMessage` where it [calls changeVisabilityTimeout](https://github.com/bbc/sqs-consumer/blob/master/src/consumer.ts#L207) is incorrectly adding the `elapsedSeconds` onto the visibility timeout.

As the [AWS docs state](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html#changing-message-visibility-timeout) , the timeout being set takes effect starting at the time that the API call to `ChangeVisibilityTImeout` is made.

> For example, if the default timeout for a queue is 60 seconds, 15 seconds have elapsed since you received the message, and you send a ChangeMessageVisibility call with VisibilityTimeout set to 10 seconds, the 10 seconds begin to count from the time that you make the ChangeMessageVisibility call. Thus, any attempt to change the visibility timeout or to delete that message 10 seconds after you initially change the visibility timeout (a total of 25 seconds) might result in an error.

<!--- Describe your changes in detail -->
**Code change**
Simply remove the `elapsedSeconds` from the call to `changeVisabilityTimeout` and `changeVisabilityTimeoutBatch`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
**Why make this change?**

The current state of the code produces unexpected, erroneous behavior for longer running jobs. For example, if a job has been running for 24 hours and the `visibilityTimeout=60` (1 minute), and the message handler fails -- then the message will be invisible for `24 hours + 1 minute` in the future after the failure occurred. This leads to unexpected gaps in time where messages are not being processed. This behavior is undocumented & undesirable.

The code will work correctly as fixed in this pull request, because the config is validated to ensure that `visibilityTimeout > hearbeatInterval`. I would consider this change to be non-breaking, because it only affects error handling and the current behavior is not what would be expected.

<!--- If it fixes an open issue, please link to the issue here. -->
See issue: https://github.com/bbc/sqs-consumer/issues/269

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
      I updated the expectations of existing tests. The only thing that can be tested is that the `visibilityTimeout` is being faithfully passed in without adding in the `elapsedSeconds`. As to testing that this is correct, that has to be done end-to-end with AWS.
- [x] All new and existing tests passed.
