### PR TITLE
Issue #275 - Fix visibility timeout error handler

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -275,7 +275,7 @@ export class Consumer extends EventEmitter {
 
   private async changeVisabilityTimeout(message: SQSMessage, timeout: number): Promise<PromiseResult<any, AWSError>> {
     try {
-      return this.sqs
+      return await this.sqs
         .changeMessageVisibility({
           QueueUrl: this.queueUrl,
           ReceiptHandle: message.ReceiptHandle,
@@ -283,7 +283,7 @@ export class Consumer extends EventEmitter {
         })
         .promise();
     } catch (err) {
-      this.emit('error', err, message);
+      this.emit('error', toSQSError(err, `Error changing visibility timeout: ${err.message}`), message);
     }
   }
 
@@ -397,11 +397,11 @@ export class Consumer extends EventEmitter {
       }))
     };
     try {
-      return this.sqs
+      return await this.sqs
         .changeMessageVisibilityBatch(params)
         .promise();
     } catch (err) {
-      this.emit('error', err, messages);
+      this.emit('error', toSQSError(err, `Error changing visibility timeout: ${err.message}`), messages);
     }
   }
 

--- a/test/consumer.ts
+++ b/test/consumer.ts
@@ -692,6 +692,60 @@ describe('Consumer', () => {
       });
       sandbox.assert.calledOnce(clearIntervalSpy);
     });
+
+    it('emit error when changing visibility timeout fails', async () => {
+      sqs.receiveMessage = stubResolve({
+        Messages: [
+          { MessageId: '1', ReceiptHandle: 'receipt-handle-1', Body: 'body-1' }
+        ]
+      });
+      consumer = new Consumer({
+        queueUrl: 'some-queue-url',
+        region: 'some-region',
+        handleMessage: () => new Promise((resolve) => setTimeout(resolve, 75000)),
+        sqs,
+        visibilityTimeout: 40,
+        heartbeatInterval: 30
+      });
+
+      const receiveErr = new MockSQSError('failed');
+      sqs.changeMessageVisibility = stubReject(receiveErr);
+
+      consumer.start();
+      const [err]: any[] = await Promise.all([pEvent(consumer, 'error'), clock.tickAsync(75000)]);
+      consumer.stop();
+
+      assert.ok(err);
+      assert.equal(err.message, 'Error changing visibility timeout: failed');
+    });
+
+    it('emit error when changing visibility timeout fails for batch handler functions', async () => {
+      sqs.receiveMessage = stubResolve({
+        Messages: [
+          { MessageId: '1', ReceiptHandle: 'receipt-handle-1', Body: 'body-1' },
+          { MessageId: '2', ReceiptHandle: 'receipt-handle-2', Body: 'body-2' }
+        ]
+      });
+      consumer = new Consumer({
+        queueUrl: 'some-queue-url',
+        region: 'some-region',
+        handleMessageBatch: () => new Promise((resolve) => setTimeout(resolve, 75000)),
+        sqs,
+        batchSize: 2,
+        visibilityTimeout: 40,
+        heartbeatInterval: 30
+      });
+
+      const receiveErr = new MockSQSError('failed');
+      sqs.changeMessageVisibilityBatch = stubReject(receiveErr);
+
+      consumer.start();
+      const [err]: any[] = await Promise.all([pEvent(consumer, 'error'), clock.tickAsync(75000)]);
+      consumer.stop();
+
+      assert.ok(err);
+      assert.equal(err.message, 'Error changing visibility timeout: failed');
+    });
   });
 
   describe('.stop', () => {


### PR DESCRIPTION
## Description
- Added `await` to `changeMessageVisibility` and `changeMessageVisibilityBatchBatch` calls to SQS
- Convert error using `toSQSError` when catching visibility timeout errors
- Added unit tests

## Motivation and Context
Fixes issue #275: visibility timeout changes are mostly used by the heartbeat (inside a Timer) that does not catch errors nor wait for the promise to be resolved. In those cases, it caused an unhandled exception/rejection.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
