### PR TITLE
Mention that AWS-SDK v2 must be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ Build SQS-based applications without the boilerplate. Just define an async funct
 
 ## Installation
 
+sqs-consumer depends on [AWS SDK for JavaScript 2.x](https://www.npmjs.com/package/aws-sdk)
+
 ```bash
-npm install sqs-consumer --save
+npm install aws-sdk sqs-consumer --save
 ```
 
 ## Usage


### PR DESCRIPTION

## Description

It's not clear that aws-sdk must be installed, and that it's the v2 that must be installed

## Motivation and Context

Wasted a lot of time figuring out that I needed to install the client separately and that I also needed to install the v2 client

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Documentation (non-breaking non-code change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
