### PR TITLE
Pause if queue doesn't exist

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -52,7 +52,12 @@ function assertOptions(options: ConsumerOptions): void {
 
 function isConnectionError(err: Error): boolean {
   if (err instanceof SQSError) {
-    return (err.statusCode === 403 || err.code === 'CredentialsError' || err.code === 'UnknownEndpoint');
+    return (
+      err.statusCode === 403
+      || err.code === 'CredentialsError'
+      || err.code === 'UnknownEndpoint'
+      || err.code === 'AWS.SimpleQueueService.NonExistentQueue'
+    );
   }
   return false;
 }
@@ -320,6 +325,7 @@ export class Consumer extends EventEmitter {
         this.emit('error', err);
         if (isConnectionError(err)) {
           debug('There was an authentication error. Pausing before retrying.');
+          debug(err.message);
           currentPollingTimeout = this.authenticationErrorTimeout;
         }
         return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Adds another check to `isConnectionError` to make sure the queue actually exists, otherwise pause like a credential error.
<!--- Describe your changes in detail -->
## Motivation and Context

This just fixes a minor annoyance when your order of operations is wrong either spinning up a localstack or deploying code before provisioning a queue.  Much like invalid creds, providing an invalid queue URL should pause for a bit before retrying, there's no need to thrash away looking for something that's not there yet.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
