### PR TITLE
Option to not don't delete messages from sqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Creates a new SQS consumer.
 * `authenticationErrorTimeout` - _Number_ - The duration (in milliseconds) to wait before retrying after an authentication error (defaults to `10000`).
 * `pollingWaitTimeMs` - _Number_ - The duration (in milliseconds) to wait before repolling the queue (defaults to `0`).
 * `sqs` - _Object_ - An optional [AWS SQS](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html) object to use if you need to configure the client manually
-
+* `shouldDeleteMessages` - _Boolean_ - Default to `true`, if you don't want the package to delete messages from sqs set this to `false`
 ### `consumer.start()`
 
 Start polling the queue for messages.

--- a/test/consumer.ts
+++ b/test/consumer.ts
@@ -752,4 +752,27 @@ describe('Consumer', () => {
       assert.isFalse(consumer.isRunning);
     });
   });
+
+  describe('delete messages property', () => {
+    beforeEach(() => {
+      consumer = new Consumer({
+        queueUrl: 'some-queue-url',
+        region: 'some-region',
+        handleMessage,
+        sqs,
+        authenticationErrorTimeout: 20,
+        shouldDeleteMessages: false
+      });
+    });
+
+    it('dont deletes the message when the handleMessage function is called', async () => {
+      handleMessage.resolves();
+
+      consumer.start();
+      await pEvent(consumer, 'message_processed');
+      consumer.stop();
+
+      sandbox.assert.notCalled(sqs.deleteMessage);
+    });
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
New property to the package if the user doesn't want to delete the messages after consuming them
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We have a use case where we 
- reading the message and starting k8s job
- pass the payload using environment variable to k8s job
- when the k8s job start running we want to delete the message
<!--- If it fixes an open issue, please link to the issue here. -->
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
