### PR TITLE
Prevent `emitError` from causing a runtime error which prevents `changeVisibilityTimeout` from being called.

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -294,8 +294,8 @@ export class Consumer extends EventEmitter {
     }
   }
 
-  private emitError(err: Error, message: SQSMessage): void {
-    if (err.name === SQSError.name) {
+  private emitError(err?: Error, message: SQSMessage): void {
+    if (err?.name === SQSError.name) {
       this.emit('error', err, message);
     } else if (err instanceof TimeoutError) {
       this.emit('timeout_error', err, message);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
If handleMessage rejects with `undefined` or `null` then `emitError` will receive the same and will cause runtime error of `TypeError: Cannot read property 'name' of undefined` and will prevent `changeVisibilityTimeout` from being called.
<!--- Describe your changes in detail -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
