### PR TITLE
Increase batchSize limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Creates a new SQS consumer.
 * `handleMessageTimeout` - _Number_ - Time in ms to wait for `handleMessage` to process a message before timing out. Emits `timeout_error` on timeout. By default, if `handleMessage` times out, the unprocessed message returns to the end of the queue.
 * `attributeNames` - _Array_ - List of queue attributes to retrieve (i.e. `['All', 'ApproximateFirstReceiveTimestamp', 'ApproximateReceiveCount']`).
 * `messageAttributeNames` - _Array_ - List of message attributes to retrieve (i.e. `['name', 'address']`).
-* `batchSize` - _Number_ - The number of messages to request from SQS when polling (default `1`). This cannot be higher than the AWS limit of 10.
+* `batchSize` - _Number_ - The number of messages to request from SQS when polling (default `1`). This cannot be higher than the AWS limit of 10000 (10 using FIFO queues).
 * `visibilityTimeout` - _Number_ - The duration (in seconds) that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request.
 * `heartbeatInterval` - _Number_ - The interval (in seconds) between requests to extend the message visibility timeout. On each heartbeat the visibility is extended by adding `visibilityTimeout` to the number of seconds since the start of the handler function. This value must less than `visibilityTimeout`.
 * `terminateVisibilityTimeout` - _Boolean_ - If true, sets the message visibility timeout to 0 after a `processing_error` (defaults to `false`).

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -41,8 +41,14 @@ function assertOptions(options: ConsumerOptions): void {
     }
   });
 
-  if (options.batchSize > 10 || options.batchSize < 1) {
+  const isFIFO = options.queueUrl.endsWith('.fifo');
+
+  if (isFIFO && (options.batchSize > 10 || options.batchSize < 1)) {
     throw new Error('SQS batchSize option must be between 1 and 10.');
+  }
+
+  if (!isFIFO && (options.batchSize > 10000 || options.batchSize < 1)) {
+    throw new Error('SQS batchSize option must be between 1 and 10000.');
   }
 
   if (options.heartbeatInterval && !(options.heartbeatInterval < options.visibilityTimeout)) {

--- a/test/consumer.ts
+++ b/test/consumer.ts
@@ -93,13 +93,24 @@ describe('Consumer', () => {
     });
   });
 
-  it('requires the batchSize option to be no greater than 10', () => {
+  it('requires the batchSize option to be no greater than 10 on FIFO queue', () => {
     assert.throws(() => {
       new Consumer({
         region: 'some-region',
-        queueUrl: 'some-queue-url',
+        queueUrl: 'http://some-queue-url.fifo',
         handleMessage,
         batchSize: 11
+      });
+    });
+  });
+
+  it('requires the batchSize option to be no greater than 10000', () => {
+    assert.throws(() => {
+      new Consumer({
+        region: 'some-region',
+        queueUrl: 'http://some-queue-url',
+        handleMessage,
+        batchSize: 10001
       });
     });
   });


### PR DESCRIPTION
## Description
Check if a queue is not FIFO and if so let to define the batchSize up to 10000.

## Motivation and Context
Currently this package doesn't let to set the batchSize > 10 on non FIFO queue. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
