### PR TITLE
chore: updating the README build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sqs-consumer
 
 [![NPM downloads](https://img.shields.io/npm/dm/sqs-consumer.svg?style=flat)](https://npmjs.org/package/sqs-consumer)
-[![Build Status](https://travis-ci.org/bbc/sqs-consumer.svg)](https://travis-ci.org/bbc/sqs-consumer) 
+[![Build Status](https://github.com/bbc/sqs-consumer/actions/workflows/test.yml/badge.svg)](https://github.com/bbc/sqs-consumer/actions/workflows/test.yml)
 [![Code Climate](https://codeclimate.com/github/BBC/sqs-consumer/badges/gpa.svg)](https://codeclimate.com/github/BBC/sqs-consumer) 
 [![Test Coverage](https://codeclimate.com/github/BBC/sqs-consumer/badges/coverage.svg)](https://codeclimate.com/github/BBC/sqs-consumer)
 


### PR DESCRIPTION
Updates the status badge in the README to use GitHub Actions rather than Travis, now that we don't/can't use Travis