### PR TITLE
feat: add NonExistentQueue to isConnectionError

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -72,7 +72,8 @@ function isConnectionError(err: Error): boolean {
     return (
       err.statusCode === 403 ||
       err.code === 'CredentialsError' ||
-      err.code === 'UnknownEndpoint'
+      err.code === 'UnknownEndpoint' ||
+      err.code === 'AWS.SimpleQueueService.NonExistentQueue'
     );
   }
   return false;


### PR DESCRIPTION
Resolves #273

**Description:**

Adds the `NonExistentQueue` error code to the `isConnectionError` so that polling will be timed out if it occurs, like other connection errors

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
_A simple explanation of what the problem is and how this PR solves it_

**Code changes:**

- Extended the isConnectionError function to check if the error code is `AWS.SimpleQueueService.NonExistentQueue`

---

**Checklist:**

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
