### PR TITLE
chore: typescript enhancements

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -18,7 +18,7 @@ import {
 import Debug from 'debug';
 import { EventEmitter } from 'events';
 
-import { AWSError } from './types';
+import { AWSError, ConsumerOptions, Events } from './types';
 import { autoBind } from './bind';
 import { SQSError, TimeoutError } from './errors';
 
@@ -93,37 +93,6 @@ function toSQSError(err: AWSError, message: string): SQSError {
 
 function hasMessages(response: ReceiveMessageCommandOutput): boolean {
   return response.Messages && response.Messages.length > 0;
-}
-
-export interface ConsumerOptions {
-  queueUrl?: string;
-  attributeNames?: string[];
-  messageAttributeNames?: string[];
-  stopped?: boolean;
-  batchSize?: number;
-  visibilityTimeout?: number;
-  waitTimeSeconds?: number;
-  authenticationErrorTimeout?: number;
-  pollingWaitTimeMs?: number;
-  terminateVisibilityTimeout?: boolean;
-  heartbeatInterval?: number;
-  sqs?: SQSClient;
-  region?: string;
-  handleMessageTimeout?: number;
-  shouldDeleteMessages?: boolean;
-  handleMessage?(message: Message): Promise<void>;
-  handleMessageBatch?(messages: Message[]): Promise<Message[] | void>;
-}
-
-interface Events {
-  response_processed: [];
-  empty: [];
-  message_received: [Message];
-  message_processed: [Message];
-  error: [Error, void | Message | Message[]];
-  timeout_error: [Error, Message];
-  processing_error: [Error, Message];
-  stopped: [];
 }
 
 export class Consumer extends EventEmitter {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export { Consumer, ConsumerOptions } from './consumer';
+export { Consumer } from './consumer';
+export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,36 @@
+import { SQSClient, Message } from '@aws-sdk/client-sqs';
+
+export interface ConsumerOptions {
+  queueUrl: string;
+  attributeNames?: string[];
+  messageAttributeNames?: string[];
+  stopped?: boolean;
+  batchSize?: number;
+  visibilityTimeout?: number;
+  waitTimeSeconds?: number;
+  authenticationErrorTimeout?: number;
+  pollingWaitTimeMs?: number;
+  terminateVisibilityTimeout?: boolean;
+  heartbeatInterval?: number;
+  sqs?: SQSClient;
+  region?: string;
+  handleMessageTimeout?: number;
+  shouldDeleteMessages?: boolean;
+  handleMessage?(message: Message): Promise<void>;
+  handleMessageBatch?(messages: Message[]): Promise<Message[] | void>;
+}
+
+export interface Events {
+  response_processed: [];
+  empty: [];
+  message_received: [Message];
+  message_processed: [Message];
+  error: [Error, void | Message | Message[]];
+  timeout_error: [Error, Message];
+  processing_error: [Error, Message];
+  stopped: [];
+}
+
 export type AWSError = {
   /**
    * Name, eg. ConditionalCheckFailedException

--- a/test/consumer.test.ts
+++ b/test/consumer.test.ts
@@ -93,15 +93,6 @@ describe('Consumer', () => {
     sandbox.restore();
   });
 
-  it('requires a queueUrl to be set', () => {
-    assert.throws(() => {
-      Consumer.create({
-        region: REGION,
-        handleMessage
-      });
-    });
-  });
-
   it('requires a handleMessage or handleMessagesBatch function to be set', () => {
     assert.throws(() => {
       new Consumer({


### PR DESCRIPTION
**Description:**

At the moment, we declare types within the same file as the main source code, and then export them individually, we should change this so that all types are declared in a single file and then exported at one.

**Changes:**

- Moved `ConsumerOptions` and `Events` from the `consumer` file to the `types` file
- Export everything from the types file automatically