### PR TITLE
chore: using typedoc to auto generate docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+
+      - name: Install Node Modules
+        run: npm ci
+
+      - name: Build Docs
+        run: npm run generate-docs
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: './public'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ test.js
 coverage
 dist
 .nyc_output
+public

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ coverage
 .vscode
 examples
 test
+public

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 bake-scripts
 dist
+public

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Consumer will receive and delete messages from the SQS queue. Ensure `sqs:Receiv
 
 ### `Consumer.create(options)`
 
-Creates a new SQS consumer using the [defined options](https://sqs-consumer.bbc.github.io/interfaces/ConsumerOptions.html).
+Creates a new SQS consumer using the [defined options](https://bbc.github.io/sqs-consumer/interfaces/ConsumerOptions.html).
 
 ### `consumer.start()`
 
@@ -120,7 +120,7 @@ Returns the current polling state of the consumer: `true` if it is actively poll
 
 ### Events
 
-Each consumer is an [`EventEmitter`](https://nodejs.org/api/events.html) and [emits these events](https://sqs-consumer.bbc.github.io/interfaces/Events.html).
+Each consumer is an [`EventEmitter`](https://nodejs.org/api/events.html) and [emits these events](https://bbc.github.io/sqs-consumer/interfaces/Events.html).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ Build SQS-based applications without the boilerplate. Just define an async funct
 
 ## Installation
 
+To install this package, simply enter the following command into your terminal (or the variant of whatever package manager you are using):
+
 ```bash
-npm install sqs-consumer --save-dev
+npm install --save-dev sqs-consumer
 ```
 
 > **Note**
@@ -43,16 +45,16 @@ app.on('processing_error', (err) => {
 app.start();
 ```
 
-- The queue is polled continuously for messages using [long polling](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html).
+- The queue is polled continuously for messages using [long polling](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html).
 - Messages are deleted from the queue once the handler function has completed successfully.
-- Throwing an error (or returning a rejected promise) from the handler function will cause the message to be left on the queue. An [SQS redrive policy](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html) can be used to move messages that cannot be processed to a dead letter queue.
+- Throwing an error (or returning a rejected promise) from the handler function will cause the message to be left on the queue. An [SQS redrive policy](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html) can be used to move messages that cannot be processed to a dead letter queue.
 - By default messages are processed one at a time – a new message won't be received until the first one has been processed. To process messages in parallel, use the `batchSize` option [detailed below](#options).
 
 You can also find some examples of sqs-consumer implemented in various ways within the [examples directory](./examples/).
 
 ### Credentials
 
-By default the consumer will look for AWS credentials in the places [specified by the AWS SDK](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials). The simplest option is to export your credentials as environment variables:
+By default the consumer will look for AWS credentials in the places [specified by the AWS SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials). The simplest option is to export your credentials as environment variables:
 
 ```bash
 export AWS_SECRET_ACCESS_KEY=...
@@ -102,28 +104,7 @@ Consumer will receive and delete messages from the SQS queue. Ensure `sqs:Receiv
 
 ### `Consumer.create(options)`
 
-Creates a new SQS consumer.
-
-#### Options
-
-| Option                       | Type      | Description                                                                                                                                                                                                                                                                                                                                                                                            |
-| ---------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `queueUrl`                   | String    | The SQS queue URL                                                                                                                                                                                                                                                                                                                                                                                      |
-| `region`                     | String    | The AWS region (default `eu-west-1`)                                                                                                                                                                                                                                                                                                                                                                   |
-| `handleMessage`              | Function  | An `async` function (or function that returns a `Promise`) to be called whenever a message is received. Receives an SQS message object as its first argument.                                                                                                                                                                                                                                          |
-| `handleMessageBatch`         | Function  | An `async` function (or function that returns a `Promise`) to be called whenever a batch of messages is received. Similar to `handleMessage` but will receive the list of messages, not each message individually. **If both are set, `handleMessageBatch` overrides `handleMessage`**. In the case that you need to ack only some of the messages, return an array with the successful messages only. |
-| `handleMessageTimeout`       | Number    | Time in ms to wait for `handleMessage` to process a message before timing out. Emits `timeout_error` on timeout. By default, if `handleMessage` times out, the unprocessed message returns to the end of the queue.                                                                                                                                                                                    |
-| `attributeNames`             | Array     | List of queue attributes to retrieve (i.e. `['All', 'ApproximateFirstReceiveTimestamp', 'ApproximateReceiveCount']`).                                                                                                                                                                                                                                                                                  |
-| `messageAttributeNames`      | Array     | List of message attributes to retrieve (i.e. `['name', 'address']`).                                                                                                                                                                                                                                                                                                                                   |
-| `batchSize`                  | Number    | The number of messages to request from SQS when polling (default `1`). This cannot be higher than the [AWS limit of 10](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html).                                                                                                                                                                              |
-| `visibilityTimeout`          | Number    | The duration (in seconds) that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request.                                                                                                                                                                                                                                                   |
-| `heartbeatInterval`          | Number    | The interval (in seconds) between requests to extend the message visibility timeout. On each heartbeat the visibility is extended by adding `visibilityTimeout` to the number of seconds since the start of the handler function. This value must less than `visibilityTimeout`.                                                                                                                       |
-| `terminateVisibilityTimeout` | Boolean   | If true, sets the message visibility timeout to 0 after a `processing_error` (defaults to `false`).                                                                                                                                                                                                                                                                                                    |
-| `waitTimeSeconds`            | Number    | The duration (in seconds) for which the call will wait for a message to arrive in the queue before returning (defaults to `20`).                                                                                                                                                                                                                                                                       |
-| `authenticationErrorTimeout` | Number    | The duration (in milliseconds) to wait before retrying after an authentication error (defaults to `10000`).                                                                                                                                                                                                                                                                                            |
-| `pollingWaitTimeMs`          | Number    | The duration (in milliseconds) to wait before repolling the queue (defaults to `0`).                                                                                                                                                                                                                                                                                                                   |
-| `sqs`                        | SQSClient | An optional [SQS Client](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-sqs/classes/sqsclient.html) object to use if you need to configure the client manually                                                                                                                                                                                                                  |
-| `shouldDeleteMessages`       | Boolean   | Default to `true`, if you don't want the package to delete messages from sqs set this to `false`                                                                                                                                                                                                                                                                                                       |
+Creates a new SQS consumer using the [defined options](https://sqs-consumer.bbc.github.io/interfaces/ConsumerOptions.html).
 
 ### `consumer.start()`
 
@@ -139,19 +120,14 @@ Returns the current polling state of the consumer: `true` if it is actively poll
 
 ### Events
 
-Each consumer is an [`EventEmitter`](http://nodejs.org/api/events.html) and emits the following events:
+Each consumer is an [`EventEmitter`](https://nodejs.org/api/events.html) and [emits these events](https://sqs-consumer.bbc.github.io/interfaces/Events.html).
 
-| Event                | Params             | Description                                                                                                                     |
-| -------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `error`              | `err`, `[message]` | Fired when an error occurs interacting with the queue. If the error correlates to a message, that message is included in Params |
-| `processing_error`   | `err`, `message`   | Fired when an error occurs processing the message.                                                                              |
-| `timeout_error`      | `err`, `message`   | Fired when `handleMessageTimeout` is supplied as an option and if `handleMessage` times out.                                    |
-| `message_received`   | `message`          | Fired when a message is received.                                                                                               |
-| `message_processed`  | `message`          | Fired when a message is successfully processed and removed from the queue.                                                      |
-| `response_processed` | None               | Fired after one batch of items (up to `batchSize`) has been successfully processed.                                             |
-| `stopped`            | None               | Fired when the consumer finally stops its work.                                                                                 |
-| `empty`              | None               | Fired when the queue is empty (All messages have been consumed).                                                                |
+## Contributing
 
-### Contributing
+We welcome and appreciate contributions for anyone who would like to take the time to fix a bug or implement a new feature.
 
-See contributing [guidelines](https://github.com/bbc/sqs-consumer/blob/main/.github/CONTRIBUTING.md).
+But before you get started, [please read the contributing guidelines](https://github.com/bbc/sqs-consumer/blob/main/.github/CONTRIBUTING.md) and [code of conduct](https://github.com/bbc/sqs-consumer/blob/main/.github/CODE_OF_CONDUCT.md).
+
+## License
+
+SQS Consumer is distributed under the Apache License, Version 2.0, see [LICENSE](./LICENSE) for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "prettier": "^2.8.1",
         "sinon": "^15.0.0",
         "ts-node": "^10.9.1",
+        "typedoc": "^0.23.23",
         "typescript": "^4.9.4"
       },
       "peerDependencies": {
@@ -3849,6 +3850,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
@@ -3938,6 +3945,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -3967,6 +3980,18 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
+    },
+    "node_modules/marked": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.4.tgz",
+      "integrity": "sha512-Wcc9ikX7Q5E4BYDPvh1C6QNSxrjC9tBgz+A/vAhp59KXUgachw++uMvMKiSW8oA85nopmPZcEvBoex/YLMsiyA==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4880,6 +4905,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "^6.0.0"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -5164,6 +5200,48 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.23.23",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.23.tgz",
+      "integrity": "sha512-cg1YQWj+/BU6wq74iott513U16fbrPCbyYs04PHZgvoKJIc6EY4xNobyDZh4KMfRGW8Yjv6wwIzQyoqopKOUGw==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.4",
+        "minimatch": "^5.1.1",
+        "shiki": "^0.11.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
@@ -5216,6 +5294,18 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
       "dev": true
     },
     "node_modules/which": {
@@ -8486,6 +8576,12 @@
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
@@ -8557,6 +8653,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -8578,6 +8680,12 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "marked": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.4.tgz",
+      "integrity": "sha512-Wcc9ikX7Q5E4BYDPvh1C6QNSxrjC9tBgz+A/vAhp59KXUgachw++uMvMKiSW8oA85nopmPZcEvBoex/YLMsiyA==",
       "dev": true
     },
     "merge2": {
@@ -9252,6 +9360,17 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shiki": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "^6.0.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -9455,6 +9574,38 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.23.23",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.23.tgz",
+      "integrity": "sha512-cg1YQWj+/BU6wq74iott513U16fbrPCbyYs04PHZgvoKJIc6EY4xNobyDZh4KMfRGW8Yjv6wwIzQyoqopKOUGw==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.4",
+        "minimatch": "^5.1.1",
+        "shiki": "^0.11.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
@@ -9484,6 +9635,18 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "bugs": {
     "url": "https://github.com/BBC/sqs-consumer/issues"
   },
-  "homepage": "https://sqs-consumer.bbc.github.io",
+  "homepage": "https://bbc.github.io/sqs-consumer/",
   "keywords": [
     "sqs",
     "queue",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --loglevel warn --write \"**/*.{js,json,jsx,md,ts,tsx,html}\"",
     "format:check": "prettier --check \"**/*.{js,json,jsx,md,ts,tsx,html}\"",
-    "posttest": "npm run lint && npm run format:check"
+    "posttest": "npm run lint && npm run format:check",
+    "generate-docs": "typedoc"
   },
   "repository": {
     "type": "git",
@@ -26,7 +27,7 @@
   "bugs": {
     "url": "https://github.com/BBC/sqs-consumer/issues"
   },
-  "homepage": "https://github.com/BBC/sqs-consumer",
+  "homepage": "https://sqs-consumer.bbc.github.io",
   "keywords": [
     "sqs",
     "queue",
@@ -49,6 +50,7 @@
     "prettier": "^2.8.1",
     "sinon": "^15.0.0",
     "ts-node": "^10.9.1",
+    "typedoc": "^0.23.23",
     "typescript": "^4.9.4"
   },
   "dependencies": {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -32,7 +32,7 @@ import { assertOptions, hasMessages } from './validation';
 const debug = Debug('sqs-consumer');
 
 /**
- * [Usage](https://sqs-consumer.bbc.github.io/index.html#usage)
+ * [Usage](https://bbc.github.io/sqs-consumer/index.html#usage)
  */
 export class Consumer extends EventEmitter {
   private queueUrl: string;

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -31,6 +31,9 @@ import { assertOptions, hasMessages } from './validation';
 
 const debug = Debug('sqs-consumer');
 
+/**
+ * [Usage](https://sqs-consumer.bbc.github.io/index.html#usage)
+ */
 export class Consumer extends EventEmitter {
   private queueUrl: string;
   private handleMessage: (message: Message) => Promise<void>;
@@ -79,10 +82,16 @@ export class Consumer extends EventEmitter {
     autoBind(this);
   }
 
+  /**
+   * Emits an event with the provided arguments
+   */
   emit<T extends keyof Events>(event: T, ...args: Events[T]) {
     return super.emit(event, ...args);
   }
 
+  /**
+   * Trigger a listen for all emitted events
+   */
   on<T extends keyof Events>(
     event: T,
     listener: (...args: Events[T]) => void
@@ -90,6 +99,9 @@ export class Consumer extends EventEmitter {
     return super.on(event, listener);
   }
 
+  /**
+   * Trigger a listener only once for an emitted event
+   */
   once<T extends keyof Events>(
     event: T,
     listener: (...args: Events[T]) => void
@@ -97,14 +109,23 @@ export class Consumer extends EventEmitter {
     return super.once(event, listener);
   }
 
+  /**
+   * Returns the current polling state of the consumer: `true` if it is actively polling, `false` if it is not.
+   */
   public get isRunning(): boolean {
     return !this.stopped;
   }
 
+  /**
+   * Creates a new SQS consumer.
+   */
   public static create(options: ConsumerOptions): Consumer {
     return new Consumer(options);
   }
 
+  /**
+   * Start polling the queue for messages.
+   */
   public start(): void {
     if (this.stopped) {
       debug('Starting consumer');
@@ -113,6 +134,9 @@ export class Consumer extends EventEmitter {
     }
   }
 
+  /**
+   * Stop polling the queue for messages (pre existing requests will still be made until concluded).
+   */
   public stop(): void {
     debug('Stopping consumer');
     this.stopped = true;

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -90,7 +90,7 @@ export class Consumer extends EventEmitter {
   }
 
   /**
-   * Trigger a listen for all emitted events
+   * Trigger a listener on all emitted events
    */
   on<T extends keyof Events>(
     event: T,

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,7 @@ export interface ConsumerOptions {
    */
   terminateVisibilityTimeout?: boolean;
   /**
-   * he interval (in seconds) between requests to extend the message visibility timeout.
+   * The interval (in seconds) between requests to extend the message visibility timeout.
    *
    * On each heartbeat the visibility is extended by adding `visibilityTimeout` to
    * the number of seconds since the start of the handler function.

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,33 +6,142 @@ export interface TimeoutResponse {
 }
 
 export interface ConsumerOptions {
+  /**
+   * The SQS queue URL.
+   */
   queueUrl: string;
+  /**
+   * List of queue attributes to retrieve (i.e.
+   * `['All', 'ApproximateFirstReceiveTimestamp', 'ApproximateReceiveCount']`).
+   * @defaultvalue `[]`
+   */
   attributeNames?: string[];
+  /**
+   * List of message attributes to retrieve (i.e. `['name', 'address']`).
+   * @defaultvalue `[]`
+   */
   messageAttributeNames?: string[];
+  /** @hidden */
   stopped?: boolean;
+  /**
+   * The number of messages to request from SQS when polling (default `1`).
+   *
+   * This cannot be higher than the
+   * [AWS limit of 10](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html).
+   * @defaultvalue `1`
+   */
   batchSize?: number;
+  /**
+   * The duration (in seconds) that the received messages are hidden from subsequent
+   * retrieve requests after being retrieved by a ReceiveMessage request.
+   */
   visibilityTimeout?: number;
+  /**
+   * The duration (in seconds) for which the call will wait for a message to arrive in
+   * the queue before returning.
+   * @defaultvalue `20`
+   */
   waitTimeSeconds?: number;
+  /**
+   * The duration (in milliseconds) to wait before retrying after an authentication error.
+   * @defaultvalue `10000`
+   */
   authenticationErrorTimeout?: number;
+  /**
+   * The duration (in milliseconds) to wait before repolling the queue.
+   * @defaultvalue `0`
+   */
   pollingWaitTimeMs?: number;
+  /**
+   * If true, sets the message visibility timeout to 0 after a `processing_error`.
+   * @defaultvalue `false`
+   */
   terminateVisibilityTimeout?: boolean;
+  /**
+   * he interval (in seconds) between requests to extend the message visibility timeout.
+   *
+   * On each heartbeat the visibility is extended by adding `visibilityTimeout` to
+   * the number of seconds since the start of the handler function.
+   *
+   * This value must less than `visibilityTimeout`.
+   */
   heartbeatInterval?: number;
+  /**
+   * An optional [SQS Client](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-sqs/classes/sqsclient.html)
+   * object to use if you need to configure the client manually.
+   */
   sqs?: SQSClient;
+  /**
+   * The AWS region.
+   * @defaultValue `eu-west-1`
+   */
   region?: string;
+  /**
+   * Time in ms to wait for `handleMessage` to process a message before timing out.
+   *
+   * Emits `timeout_error` on timeout. By default, if `handleMessage` times out,
+   * the unprocessed message returns to the end of the queue.
+   */
   handleMessageTimeout?: number;
+  /**
+   * Default to `true`, if you don't want the package to delete messages from sqs
+   * set this to `false`.
+   * @defaultvalue `true`
+   */
   shouldDeleteMessages?: boolean;
+  /**
+   * An `async` function (or function that returns a `Promise`) to be called whenever
+   * a message is received.
+   */
   handleMessage?(message: Message): Promise<void>;
+  /**
+   * An `async` function (or function that returns a `Promise`) to be called whenever
+   * a batch of messages is received. Similar to `handleMessage` but will receive the
+   * list of messages, not each message individually.
+   *
+   * **If both are set, `handleMessageBatch` overrides `handleMessage`**.
+   *
+   * In the case that you need to ack only some of the messages, return an array with
+   * the successful messages only.
+   */
   handleMessageBatch?(messages: Message[]): Promise<Message[] | void>;
 }
 
 export interface Events {
+  /**
+   * Fired after one batch of items (up to `batchSize`) has been successfully processed.
+   */
   response_processed: [];
+  /**
+   * Fired when the queue is empty (All messages have been consumed).
+   */
   empty: [];
+  /**
+   * Fired when a message is received.
+   */
   message_received: [Message];
+  /**
+   * Fired when a message is successfully processed and removed from the queue.
+   */
   message_processed: [Message];
+  /**
+   * Fired when an error occurs interacting with the queue.
+   *
+   * If the error correlates to a message, that message is included in Params
+   */
   error: [Error, void | Message | Message[]];
+  /**
+   * Fired when `handleMessageTimeout` is supplied as an option and if
+   * `handleMessage` times out.
+   */
   timeout_error: [Error, Message];
+  /**
+   * Fired when an error occurs processing the message.
+   */
   processing_error: [Error, Message];
+  /**
+   * Fired when the consumer finally stops its work.
+   */
   stopped: [];
 }
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "sort": ["kind", "instance-first", "required-first", "alphabetical"],
+  "treatWarningsAsErrors": false,
+  "searchInComments": true,
+  "entryPoints": ["./src/index.ts"],
+  "out": "public",
+  "name": "SQS Consumer",
+  "hideGenerator": true,
+  "navigationLinks": {
+    "GitHub": "https://github.com/bbc/sqs-consumer"
+  }
+}


### PR DESCRIPTION
In this PR, we are using the package typedoc to automatically generate documentation from our TypeScript files, which will allow us to:

- Simplify the readme as currently everything has to go there and it can be hard to understand
- Remove the requirement to manually update the documentation, outside of adding comments to your code
- Adds more documentation within the code itself as this is how the docs are generated
- Creates a homepage for sqs-consumer, where we could provide more information about functionality in the future

## Changes

- Added a workflow to automatically deploy the docs when deployed to main
- Added the dependency `typedoc` to generate the docs
- Added comments to the code to document the type definitions and functionality - basic
- Cleaned up the README (hopefully https://bbc.github.io/sqs-consumer/ is our GitHub Pages domain)