### PR TITLE
chore: dropping node 14 support

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ npm install --save-dev sqs-consumer
 > npm install sqs-consumer@5.8.0 --save-dev
 > ```
 
+### Node version
+
+From v7 and above, this library will only support Node v16 or above. If you are still using Node 14, please use a previous version of the library.
+
+This decision was made due to the removal of security support from the Node.JS team from April 30th, 2023.
+
 ## Usage
 
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqs-consumer",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sqs-consumer",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.258.0",
@@ -32,6 +32,9 @@
         "ts-node": "^10.9.1",
         "typedoc": "^0.23.24",
         "typescript": "^4.9.4"
+      },
+      "engines": {
+        "node": ">=16.19.0"
       },
       "peerDependencies": {
         "@aws-sdk/client-sqs": "^3.258.0"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Build SQS-based Node applications without the boilerplate",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "engines" : {
+    "node" : ">=16.19.0"
+  },
   "scripts": {
     "build": "npm run clean && tsc",
     "watch": "tsc --watch",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Build SQS-based Node applications without the boilerplate",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "engines" : {
-    "node" : ">=16.19.0"
+  "engines": {
+    "node": ">=16.19.0"
   },
   "scripts": {
     "build": "npm run clean && tsc",


### PR DESCRIPTION
Resolves #362

**Description:**

This PR removes support for Node v14 due to the removal of security support from April 30th, 2023

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

To support new functionality, such as the AbortController, we would need a polyfill to continue to support this version.

Alongside this, if the version is not supported by the Node.JS team, we cannot confidently support Node 14 for our users without further work.

**Code changes:**

- Changed the coverage CI to run from the LTS
- Remove v14 from the test CI matrix
- Added a note to the README to make it clear that we no longer support this version of Node
- Added a minimum engine version to the package.json so that this is clear (`16.19.0`)

---

**Checklist:**

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
