### PR TITLE
fix: gracefully handle errors in the e2e tests

### DIFF
--- a/test/config/cucumber.js
+++ b/test/config/cucumber.js
@@ -3,6 +3,7 @@ module.exports = {
     parallel: 0,
     format: ['html:test/reports/cucumber-report.html'],
     publishQuiet: true,
-    paths: ['test/features']
+    paths: ['test/features'],
+    forceExit: true
   }
 };

--- a/test/features/step_definitions/handleMessage.js
+++ b/test/features/step_definitions/handleMessage.js
@@ -1,4 +1,4 @@
-const { Given, Then } = require('@cucumber/cucumber');
+const { Given, Then, After } = require('@cucumber/cucumber');
 const assert = require('assert');
 const { PurgeQueueCommand } = require('@aws-sdk/client-sqs');
 const pEvent = require('p-event');
@@ -85,3 +85,7 @@ Then(
     assert.strictEqual(consumer.isRunning, false);
   }
 );
+
+After(() => {
+  return consumer.stop();
+});

--- a/test/features/step_definitions/handleMessageBatch.js
+++ b/test/features/step_definitions/handleMessageBatch.js
@@ -1,4 +1,4 @@
-const { Given, Then } = require('@cucumber/cucumber');
+const { Given, Then, After } = require('@cucumber/cucumber');
 const assert = require('assert');
 const { PurgeQueueCommand } = require('@aws-sdk/client-sqs');
 const pEvent = require('p-event');
@@ -79,3 +79,7 @@ Then(
     assert.strictEqual(consumer.isRunning, false);
   }
 );
+
+After(() => {
+  return consumer.stop();
+});


### PR DESCRIPTION
Resolves NA

**Description:**

Made changes to the Cucumber config to fix how it responds to an error from SQS so that it is gracefully handled

**Type of change:**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

When an error occurs in the E2E tests, the Consumer was not correctly stopped and so it was still listening for messages, this causes subsequent tests to fail as the previous run is handling messages instead of the new run.

Alongside this, Cucumber was not exiting after an error, which caused it to run indefinitely.

**Code changes:**

- Changed config to force Cucumber to exit
- Added `After` to the tests to stop the Consumer after a test has finished running

---

**Checklist:**

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
