### PR TITLE
fix: make the stop options optional

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -102,7 +102,7 @@ export class Consumer extends TypedEventEmitter {
   /**
    * Stop polling the queue for messages (pre existing requests will still be made until concluded).
    */
-  public stop(options: StopOptions): void {
+  public stop(options?: StopOptions): void {
     if (this.stopped) {
       debug('Consumer was already stopped');
       return;


### PR DESCRIPTION
Resolves #372

**Description:**
Fixed the options parameter of `consumer.stop` to be optional (in the code it was treated as an optional parameter - [here](https://github.com/bbc/sqs-consumer/blob/b2fd52735d67768047f65a8213cb8cd50844adc2/src/consumer.ts#L119)).

**Type of change:**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
The option object is treated as required in the code but declared as required in the function's type.

**Code changes:**

* Changed the type of `options` to be optional.

---

**Checklist:**

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
