### PR TITLE
fix: correctly documenting region's default value

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -69,7 +69,7 @@ export interface ConsumerOptions {
   sqs?: SQSClient;
   /**
    * The AWS region.
-   * @defaultValue `eu-west-1`
+   * @defaultValue process.env.AWS_REGION || `eu-west-1`
    */
   region?: string;
   /**


### PR DESCRIPTION
As noted in this discussion:

https://github.com/bbc/sqs-consumer/discussions/377

We are not correctly documenting the default value for the region option, this PR resolves that by changing to documented value to `process.env.AWS_REGION || "eu-west-1"`