### PR TITLE
feat: adding the ability to update visibilityTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ By default, the value of `abort` is set to `false` which means pre existing requ
 
 Returns the current polling state of the consumer: `true` if it is actively polling, `false` if it is not.
 
+### `consumer.updateOption(option, value)`
+
+Updates the provided option with the provided value.
+
+You can [find out more about this here](https://bbc.github.io/sqs-consumer/public/classes/Consumer.html#updateOption).
+
 ### Events
 
 Each consumer is an [`EventEmitter`](https://nodejs.org/api/events.html) and [emits these events](https://bbc.github.io/sqs-consumer/interfaces/Events.html).

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -144,7 +144,10 @@ export class Consumer extends TypedEventEmitter {
    * @param option The option that you want to update
    * @param value The value to set the option to
    */
-  public updateOption(option: UpdatableOptions, value: ConsumerOptions[UpdatableOptions]) {
+  public updateOption(
+    option: UpdatableOptions,
+    value: ConsumerOptions[UpdatableOptions]
+  ) {
     switch (option) {
       case 'visibilityTimeout':
         if (typeof value === 'number') {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -17,7 +17,12 @@ import {
 } from '@aws-sdk/client-sqs';
 import Debug from 'debug';
 
-import { ConsumerOptions, TypedEventEmitter, StopOptions } from './types';
+import {
+  ConsumerOptions,
+  TypedEventEmitter,
+  StopOptions,
+  UpdatableOptions
+} from './types';
 import { autoBind } from './bind';
 import {
   SQSError,
@@ -132,6 +137,28 @@ export class Consumer extends TypedEventEmitter {
    */
   public get isRunning(): boolean {
     return !this.stopped;
+  }
+
+  /**
+   * Updates the provided option to the provided value.
+   * @param option The option that you want to update
+   * @param value The value to set the option to
+   */
+  public updateOption(option: UpdatableOptions, value: ConsumerOptions[UpdatableOptions]) {
+    switch (option) {
+      case 'visibilityTimeout':
+        if (typeof value === 'number') {
+          debug(`Updating the visibilityTimeout option to the value ${value}`);
+
+          this.visibilityTimeout = value;
+
+          this.emit('option_updated', option, value);
+        }
+
+        break;
+      default:
+        break;
+    }
   }
 
   /**

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -150,13 +150,18 @@ export class Consumer extends TypedEventEmitter {
   ) {
     switch (option) {
       case 'visibilityTimeout':
-        if (typeof value === 'number') {
-          debug(`Updating the visibilityTimeout option to the value ${value}`);
-
-          this.visibilityTimeout = value;
-
-          this.emit('option_updated', option, value);
+        if (
+          typeof value !== 'number' ||
+          (this.heartbeatInterval && value <= this.heartbeatInterval)
+        ) {
+          break;
         }
+
+        debug(`Updating the visibilityTimeout option to the value ${value}`);
+
+        this.visibilityTimeout = value;
+
+        this.emit('option_updated', option, value);
 
         break;
       default:

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -143,9 +143,7 @@ export class Consumer extends TypedEventEmitter {
    * Updates visibilityTimeout to the provided value.
    * @param value The value to set visibilityTimeout to
    */
-  private updateVisibilityTimeout(
-    value: ConsumerOptions['visibilityTimeout']
-  ) {
+  private updateVisibilityTimeout(value: ConsumerOptions['visibilityTimeout']) {
     if (typeof value !== 'number') {
       throw new Error('visibilityTimeout must be a number');
     }

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -150,11 +150,17 @@ export class Consumer extends TypedEventEmitter {
   ) {
     switch (option) {
       case 'visibilityTimeout':
+        if (typeof value !== 'number') {
+          throw new Error('visibilityTimeout must be a number');
+        }
+
         if (
           typeof value !== 'number' ||
           (this.heartbeatInterval && value <= this.heartbeatInterval)
         ) {
-          break;
+          throw new Error(
+            'heartbeatInterval must be less than visibilityTimeout.'
+          );
         }
 
         debug(`Updating the visibilityTimeout option to the value ${value}`);
@@ -165,7 +171,7 @@ export class Consumer extends TypedEventEmitter {
 
         break;
       default:
-        break;
+        throw new Error(`The update ${option} cannot be updated`);
     }
   }
 

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -140,6 +140,31 @@ export class Consumer extends TypedEventEmitter {
   }
 
   /**
+   * Updates visibilityTimeout to the provided value.
+   * @param value The value to set visibilityTimeout to
+   */
+  private updateVisibilityTimeout(
+    value: ConsumerOptions['visibilityTimeout']
+  ) {
+    if (typeof value !== 'number') {
+      throw new Error('visibilityTimeout must be a number');
+    }
+
+    if (
+      typeof value !== 'number' ||
+      (this.heartbeatInterval && value <= this.heartbeatInterval)
+    ) {
+      throw new Error('heartbeatInterval must be less than visibilityTimeout.');
+    }
+
+    debug(`Updating the visibilityTimeout option to the value ${value}`);
+
+    this.visibilityTimeout = value;
+
+    this.emit('option_updated', 'visibilityTimeout', value);
+  }
+
+  /**
    * Updates the provided option to the provided value.
    * @param option The option that you want to update
    * @param value The value to set the option to
@@ -150,25 +175,7 @@ export class Consumer extends TypedEventEmitter {
   ) {
     switch (option) {
       case 'visibilityTimeout':
-        if (typeof value !== 'number') {
-          throw new Error('visibilityTimeout must be a number');
-        }
-
-        if (
-          typeof value !== 'number' ||
-          (this.heartbeatInterval && value <= this.heartbeatInterval)
-        ) {
-          throw new Error(
-            'heartbeatInterval must be less than visibilityTimeout.'
-          );
-        }
-
-        debug(`Updating the visibilityTimeout option to the value ${value}`);
-
-        this.visibilityTimeout = value;
-
-        this.emit('option_updated', option, value);
-
+        this.updateVisibilityTimeout(value);
         break;
       default:
         throw new Error(`The update ${option} cannot be updated`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,7 +106,7 @@ export interface ConsumerOptions {
   handleMessageBatch?(messages: Message[]): Promise<Message[] | void>;
 }
 
-export type UpdatableOptions = 'visibilityTimeout'
+export type UpdatableOptions = 'visibilityTimeout';
 
 export interface StopOptions {
   /**
@@ -160,7 +160,7 @@ export interface Events {
   /**
    * Fired when an option is updated
    */
-  option_updated: [UpdatableOptions, ConsumerOptions[UpdatableOptions]]
+  option_updated: [UpdatableOptions, ConsumerOptions[UpdatableOptions]];
 }
 
 export class TypedEventEmitter extends EventEmitter {

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,8 @@ export interface ConsumerOptions {
   handleMessageBatch?(messages: Message[]): Promise<Message[] | void>;
 }
 
+export type UpdatableOptions = 'visibilityTimeout'
+
 export interface StopOptions {
   /**
    * Default to `false`, if you want the stop action to also abort requests to SQS
@@ -155,6 +157,10 @@ export interface Events {
    * Fired when the consumer finally stops its work.
    */
   stopped: [];
+  /**
+   * Fired when an option is updated
+   */
+  option_updated: [UpdatableOptions, ConsumerOptions[UpdatableOptions]]
 }
 
 export class TypedEventEmitter extends EventEmitter {

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -1175,6 +1175,23 @@ describe('Consumer', () => {
     });
   });
 
+  describe('updateOption', async () => {
+    it('updates the visibilityTimeout option and emits an event', async () => {
+      const optionUpdatedListener = sandbox.stub();
+      consumer.on('option_updated', optionUpdatedListener);
+
+      consumer.updateOption('visibilityTimeout', 45);
+
+      assert.equal(consumer.visibilityTimeout, 45);
+
+      sandbox.assert.calledWithMatch(
+        optionUpdatedListener,
+        'visibilityTimeout',
+        45
+      );
+    });
+  });
+
   describe('delete messages property', () => {
     beforeEach(() => {
       consumer = new Consumer({

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -101,7 +101,7 @@ describe('Consumer', () => {
         region: REGION,
         queueUrl: QUEUE_URL
       });
-    });
+    }, `Missing SQS consumer option [ handleMessage or handleMessageBatch ].`);
   });
 
   it('requires the batchSize option to be no greater than 10', () => {
@@ -112,7 +112,7 @@ describe('Consumer', () => {
         handleMessage,
         batchSize: 11
       });
-    });
+    }, 'SQS batchSize option must be between 1 and 10.');
   });
 
   it('requires the batchSize option to be greater than 0', () => {
@@ -123,7 +123,7 @@ describe('Consumer', () => {
         handleMessage,
         batchSize: -1
       });
-    });
+    }, 'SQS batchSize option must be between 1 and 10.');
   });
 
   it('requires visibilityTimeout to be set with heartbeatInterval', () => {
@@ -134,7 +134,7 @@ describe('Consumer', () => {
         handleMessage,
         heartbeatInterval: 30
       });
-    });
+    }, 'heartbeatInterval must be less than visibilityTimeout.');
   });
 
   it('requires heartbeatInterval to be less than visibilityTimeout', () => {
@@ -146,7 +146,7 @@ describe('Consumer', () => {
         heartbeatInterval: 30,
         visibilityTimeout: 30
       });
-    });
+    }, 'heartbeatInterval must be less than visibilityTimeout.');
   });
 
   describe('.create', () => {
@@ -1202,7 +1202,9 @@ describe('Consumer', () => {
       const optionUpdatedListener = sandbox.stub();
       consumer.on('option_updated', optionUpdatedListener);
 
-      consumer.updateOption('visibilityTimeout', 'value');
+      assert.throws(() => {
+        consumer.updateOption('visibilityTimeout', 'value');
+      }, 'visibilityTimeout must be a number');
 
       assert.equal(consumer.visibilityTimeout, 60);
 
@@ -1221,11 +1223,26 @@ describe('Consumer', () => {
       const optionUpdatedListener = sandbox.stub();
       consumer.on('option_updated', optionUpdatedListener);
 
-      consumer.updateOption('visibilityTimeout', 30);
+      assert.throws(() => {
+        consumer.updateOption('visibilityTimeout', 30);
+      }, 'heartbeatInterval must be less than visibilityTimeout.');
 
       assert.equal(consumer.visibilityTimeout, 60);
 
       sandbox.assert.notCalled(optionUpdatedListener);
+    });
+
+    it('throws an error for an unknown option', () => {
+      consumer = new Consumer({
+        region: REGION,
+        queueUrl: QUEUE_URL,
+        handleMessage,
+        visibilityTimeout: 60
+      });
+
+      assert.throws(() => {
+        consumer.updateOption('unknown', 'value');
+      }, `The update unknown cannot be updated`);
     });
   });
 

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -1176,7 +1176,7 @@ describe('Consumer', () => {
   });
 
   describe('updateOption', async () => {
-    it('updates the visibilityTimeout option and emits an event', async () => {
+    it('updates the visibilityTimeout option and emits an event', () => {
       const optionUpdatedListener = sandbox.stub();
       consumer.on('option_updated', optionUpdatedListener);
 
@@ -1189,6 +1189,43 @@ describe('Consumer', () => {
         'visibilityTimeout',
         45
       );
+    });
+
+    it('does not update the visibilityTimeout if the value is not a number', () => {
+      consumer = new Consumer({
+        region: REGION,
+        queueUrl: QUEUE_URL,
+        handleMessage,
+        visibilityTimeout: 60
+      });
+
+      const optionUpdatedListener = sandbox.stub();
+      consumer.on('option_updated', optionUpdatedListener);
+
+      consumer.updateOption('visibilityTimeout', 'value');
+
+      assert.equal(consumer.visibilityTimeout, 60);
+
+      sandbox.assert.notCalled(optionUpdatedListener);
+    });
+
+    it('does not update the visibilityTimeout if the value is less than the heartbeatInterval', () => {
+      consumer = new Consumer({
+        region: REGION,
+        queueUrl: QUEUE_URL,
+        handleMessage,
+        heartbeatInterval: 30,
+        visibilityTimeout: 60
+      });
+
+      const optionUpdatedListener = sandbox.stub();
+      consumer.on('option_updated', optionUpdatedListener);
+
+      consumer.updateOption('visibilityTimeout', 30);
+
+      assert.equal(consumer.visibilityTimeout, 60);
+
+      sandbox.assert.notCalled(optionUpdatedListener);
     });
   });
 


### PR DESCRIPTION
Resolves #370

**Description:**

As described in the feature request, this PR will add the ability for users to programatically update options for the Consumer. At the moment, this has only been configured with the ability to update `visibilityTimeout`, but in a way that'll be expandable in the future.

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

When an external factor occurs, users may want to trigger an update to the `visibilityTimeout` option that will take effect from that point on.

Rather than stopping and then restarting the Consumer, they would like to do this in the current instance.

**Code changes:**

- Added a new public method `.updateOption()`, this will take an option and a value and then update the provided option with the provided value
- Updated documentation around this

---

**Checklist:**

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
