### PR TITLE
fix: timeout ids are not being set correctly for parallel running

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -35,7 +35,6 @@ const debug = Debug('sqs-consumer');
  */
 export class Consumer extends TypedEventEmitter {
   private pollingTimeoutId: NodeJS.Timeout | undefined = undefined;
-  private handleMessageTimeoutId: NodeJS.Timeout | undefined = undefined;
   private stopped = true;
   private queueUrl: string;
   private handleMessage: (message: Message) => Promise<Message | void>;
@@ -388,12 +387,14 @@ export class Consumer extends TypedEventEmitter {
    * @param message The message that was received from SQS
    */
   private async executeHandler(message: Message): Promise<Message> {
+    let handleMessageTimeoutId: NodeJS.Timeout | undefined = undefined;
+
     try {
       let result;
 
       if (this.handleMessageTimeout) {
         const pending = new Promise((_, reject) => {
-          this.handleMessageTimeoutId = setTimeout((): void => {
+          handleMessageTimeoutId = setTimeout((): void => {
             reject(new TimeoutError());
           }, this.handleMessageTimeout);
         });
@@ -410,8 +411,8 @@ export class Consumer extends TypedEventEmitter {
           : `Unexpected message handler failure: ${err.message}`;
       throw err;
     } finally {
-      if (this.handleMessageTimeoutId) {
-        clearTimeout(this.handleMessageTimeoutId);
+      if (handleMessageTimeoutId) {
+        clearTimeout(handleMessageTimeoutId);
       }
     }
   }


### PR DESCRIPTION
Resolves #376

**Description:**

As described in the issue.

**Type of change:**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

heartbeatTimeoutId was previously set globally, rather than within the processor function, which means that it errors when the Consumer is processing messages in parallel.

**Code changes:**

- Changed `heartbeatTimeoutId` to be set within the processing functions.
- Changed `handleMessageTimeoutId` to be set within the execute handler function
