### PR TITLE
chore: removing dev from the install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Build SQS-based applications without the boilerplate. Just define an async funct
 To install this package, simply enter the following command into your terminal (or the variant of whatever package manager you are using):
 
 ```bash
-npm install --save-dev sqs-consumer
+npm install sqs-consumer
 ```
 
 > **Note**
 > This library assumes you are using [AWS SDK v3](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-sqs/index.html). If you are using v2, please install v5.8.0:
 >
 > ```bash
-> npm install sqs-consumer@5.8.0 --save-dev
+> npm install sqs-consumer@5.8.0
 > ```
 
 ### Node version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqs-consumer",
-  "version": "7.0.1",
+  "version": "7.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sqs-consumer",
-      "version": "7.0.1",
+      "version": "7.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.258.0",


### PR DESCRIPTION
As discussed here:

https://github.com/bbc/sqs-consumer/discussions/382

We probably don't need to suggest always installing as a devDependency, while that is a use case, the most common use case is probably for it not to be.

This PR removes the dev flag from the README.