### PR TITLE
feat: re-export message interface

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -1,6 +1,5 @@
 import {
   SQSClient,
-  Message,
   ChangeMessageVisibilityCommand,
   ChangeMessageVisibilityCommandInput,
   ChangeMessageVisibilityCommandOutput,
@@ -18,6 +17,7 @@ import {
 import Debug from 'debug';
 
 import {
+  Message,
   ConsumerOptions,
   TypedEventEmitter,
   StopOptions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import { SQSClient, Message } from '@aws-sdk/client-sqs';
 import { EventEmitter } from 'events';
 
-export interface ConsumerOptions {
+interface ConsumerOptions {
   /**
    * The SQS queue URL.
    */
@@ -106,9 +106,9 @@ export interface ConsumerOptions {
   handleMessageBatch?(messages: Message[]): Promise<Message[] | void>;
 }
 
-export type UpdatableOptions = 'visibilityTimeout';
+type UpdatableOptions = 'visibilityTimeout';
 
-export interface StopOptions {
+interface StopOptions {
   /**
    * Default to `false`, if you want the stop action to also abort requests to SQS
    * set this to `true`.
@@ -117,7 +117,7 @@ export interface StopOptions {
   abort?: boolean;
 }
 
-export interface Events {
+interface Events {
   /**
    * Fired after one batch of items (up to `batchSize`) has been successfully processed.
    */
@@ -163,7 +163,7 @@ export interface Events {
   option_updated: [UpdatableOptions, ConsumerOptions[UpdatableOptions]];
 }
 
-export class TypedEventEmitter extends EventEmitter {
+class TypedEventEmitter extends EventEmitter {
   /**
    * Trigger a listener on all emitted events
    * @param event The name of the event to listen to
@@ -264,4 +264,13 @@ export type AWSError = {
      */
     totalRetryDelay?: number;
   };
+};
+
+export {
+  Message,
+  ConsumerOptions,
+  UpdatableOptions,
+  StopOptions,
+  Events,
+  TypedEventEmitter
 };


### PR DESCRIPTION
Resolves #384

**Description:**

It has been suggested that the package would be easier to use for developers if the library re-exported the AWS interface `Message`, so that they don't have to import it from the AWS library directly.

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

This PR re-exports the interface from the `types` file and also changes how we use the interface internally to also use that export.

**Code changes:**

- Changed the type exports to export at the end of the file rather than individually (this allows us to do the next item)
- Re export the `Message` type from the AWS SDK

---