### PR TITLE
feat: emit a started event on consumer start

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -98,6 +98,7 @@ export class Consumer extends TypedEventEmitter {
     if (this.stopped) {
       debug('Starting consumer');
       this.stopped = false;
+      this.emit('started');
       this.poll();
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,6 +154,10 @@ export interface Events {
    */
   aborted: [];
   /**
+   * Fired when the consumer starts its work..
+   */
+  started: [];
+  /**
    * Fired when the consumer finally stops its work.
    */
   stopped: [];

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -165,6 +165,17 @@ describe('Consumer', () => {
   });
 
   describe('.start', () => {
+    it('fires an event when the consumer is started', async () => {
+      const handleStart = sandbox.stub().returns(null);
+
+      consumer.on('started', handleStart);
+      
+      consumer.start();
+      consumer.stop();
+
+      sandbox.assert.calledOnce(handleStart);
+    })
+
     it('fires an error event when an error occurs receiving a message', async () => {
       const receiveErr = new Error('Receive error');
 

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -169,12 +169,12 @@ describe('Consumer', () => {
       const handleStart = sandbox.stub().returns(null);
 
       consumer.on('started', handleStart);
-      
+
       consumer.start();
       consumer.stop();
 
       sandbox.assert.calledOnce(handleStart);
-    })
+    });
 
     it('fires an error event when an error occurs receiving a message', async () => {
       const receiveErr = new Error('Receive error');


### PR DESCRIPTION
Resolves #388

**Description:**

Fires a `started` event when the Consumer is started, like we do when it is stopped.

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

Allows implementations to extend functionality when the event is recieved

**Code changes:**

- Added the new event
- Emit the event on start
