### PR TITLE
fix: once event is not only firing once

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -184,7 +184,7 @@ export class TypedEventEmitter extends EventEmitter {
     event: E,
     listener: (...args: Events[E]) => void
   ): this {
-    return super.on(event, listener);
+    return super.once(event, listener);
   }
   /**
    * Emits an event with the provided arguments

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -1086,6 +1086,44 @@ describe('Consumer', () => {
     });
   });
 
+  describe('event listeners', () => {
+    it('fires the event multiple times', async () => {
+      sqs.send.withArgs(mockReceiveMessage).resolves({});
+
+      const handleEmpty = sandbox.stub().returns(null);
+
+      consumer.on('empty', handleEmpty);
+
+      consumer.start();
+
+      await clock.tickAsync(0);
+
+      consumer.stop();
+
+      await clock.runAllAsync();
+
+      sandbox.assert.calledTwice(handleEmpty);
+    });
+
+    it('fires the events only once', async () => {
+      sqs.send.withArgs(mockReceiveMessage).resolves({});
+
+      const handleEmpty = sandbox.stub().returns(null);
+
+      consumer.once('empty', handleEmpty);
+
+      consumer.start();
+
+      await clock.tickAsync(0);
+
+      consumer.stop();
+
+      await clock.runAllAsync();
+
+      sandbox.assert.calledOnce(handleEmpty);
+    });
+  });
+
   describe('.stop', () => {
     it('stops the consumer polling for messages', async () => {
       const handleStop = sandbox.stub().returns(null);


### PR DESCRIPTION
Resolves #393

**Description:**

The `.once` event is not actually being fired only once due to the node API in the background being `.on` rather than `.once`

**Type of change:**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

This changes the API that's used in the background for once to also be once

**Code changes:**

- Fixed the use of the background emitter for once
- Added a test for on and once event emitters
