### PR TITLE
feat: extending the update api to update batchsize and waittimeseconds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqs-consumer",
-  "version": "7.1.0-canary.1",
+  "version": "7.1.0-canary.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sqs-consumer",
-      "version": "7.1.0-canary.1",
+      "version": "7.1.0-canary.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.258.0",

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -30,7 +30,7 @@ import {
   toSQSError,
   isConnectionError
 } from './errors';
-import { assertOptions, hasMessages } from './validation';
+import { validateOption, assertOptions, hasMessages } from './validation';
 import { abortController } from './controllers';
 
 const debug = Debug('sqs-consumer');
@@ -139,86 +139,21 @@ export class Consumer extends TypedEventEmitter {
   }
 
   /**
-   * Updates visibilityTimeout to the provided value.
+   * Validates and then updates the provided option to the provided value.
+   * @param option The option to validate and then update
    * @param value The value to set visibilityTimeout to
-   */
-  private updateVisibilityTimeout(value: ConsumerOptions['visibilityTimeout']) {
-    if (typeof value !== 'number') {
-      throw new Error('visibilityTimeout must be a number');
-    }
-
-    if (
-      typeof value !== 'number' ||
-      (this.heartbeatInterval && value <= this.heartbeatInterval)
-    ) {
-      throw new Error('heartbeatInterval must be less than visibilityTimeout.');
-    }
-
-    debug(`Updating the visibilityTimeout option to the value ${value}`);
-
-    this.visibilityTimeout = value;
-
-    this.emit('option_updated', 'visibilityTimeout', value);
-  }
-
-  /**
-   * Updates batchSize to the provided value.
-   * @param value The value to set batchSize to
-   */
-  private updateBatchSize(value: ConsumerOptions['batchSize']) {
-    if (typeof value !== 'number') {
-      throw new Error('batchSize must be a number');
-    }
-
-    if (value > 10 || value < 1) {
-      throw new Error('batchSize must be between 1 and 10.');
-    }
-
-    debug(`Updating the batchSize option to the value ${value}`);
-
-    this.batchSize = value;
-
-    this.emit('option_updated', 'batchSize', value);
-  }
-
-  /**
-   * Updates waitTimeSeconds to the provided value.
-   * @param value The value to set waitTimeSeconds to
-   */
-  private updateWaitTimeSeconds(value: ConsumerOptions['waitTimeSeconds']) {
-    if (typeof value !== 'number') {
-      throw new Error('waitTimeSeconds must be a number');
-    }
-
-    debug(`Updating the waitTimeSeconds option to the value ${value}`);
-
-    this.waitTimeSeconds = value;
-
-    this.emit('option_updated', 'waitTimeSeconds', value);
-  }
-
-  /**
-   * Updates the provided option to the provided value.
-   * @param option The option that you want to update
-   * @param value The value to set the option to
    */
   public updateOption(
     option: UpdatableOptions,
     value: ConsumerOptions[UpdatableOptions]
   ) {
-    switch (option) {
-      case 'visibilityTimeout':
-        this.updateVisibilityTimeout(value);
-        break;
-      case 'batchSize':
-        this.updateBatchSize(value);
-        break;
-      case `waitTimeSeconds`:
-        this.updateWaitTimeSeconds(value);
-        break;
-      default:
-        throw new Error(`The update ${option} cannot be updated`);
-    }
+    validateOption(option, value, this, true);
+
+    debug(`Updating the ${option} option to the value ${value}`);
+
+    this[option] = value;
+
+    this.emit('option_updated', option, value);
   }
 
   /**

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -162,6 +162,42 @@ export class Consumer extends TypedEventEmitter {
   }
 
   /**
+   * Updates batchSize to the provided value.
+   * @param value The value to set batchSize to
+   */
+  private updateBatchSize(value: ConsumerOptions['batchSize']) {
+    if (typeof value !== 'number') {
+      throw new Error('batchSize must be a number');
+    }
+
+    if (value > 10 || value < 1) {
+      throw new Error('batchSize must be between 1 and 10.');
+    }
+
+    debug(`Updating the batchSize option to the value ${value}`);
+
+    this.batchSize = value;
+
+    this.emit('option_updated', 'batchSize', value);
+  }
+
+  /**
+   * Updates waitTimeSeconds to the provided value.
+   * @param value The value to set waitTimeSeconds to
+   */
+  private updateWaitTimeSeconds(value: ConsumerOptions['waitTimeSeconds']) {
+    if (typeof value !== 'number') {
+      throw new Error('waitTimeSeconds must be a number');
+    }
+
+    debug(`Updating the waitTimeSeconds option to the value ${value}`);
+
+    this.waitTimeSeconds = value;
+
+    this.emit('option_updated', 'waitTimeSeconds', value);
+  }
+
+  /**
    * Updates the provided option to the provided value.
    * @param option The option that you want to update
    * @param value The value to set the option to
@@ -173,6 +209,12 @@ export class Consumer extends TypedEventEmitter {
     switch (option) {
       case 'visibilityTimeout':
         this.updateVisibilityTimeout(value);
+        break;
+      case 'batchSize':
+        this.updateBatchSize(value);
+        break;
+      case `waitTimeSeconds`:
+        this.updateWaitTimeSeconds(value);
         break;
       default:
         throw new Error(`The update ${option} cannot be updated`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,7 +106,10 @@ export interface ConsumerOptions {
   handleMessageBatch?(messages: Message[]): Promise<Message[] | void>;
 }
 
-export type UpdatableOptions = 'visibilityTimeout';
+export type UpdatableOptions =
+  | 'visibilityTimeout'
+  | 'batchSize'
+  | 'waitTimeSeconds';
 
 export interface StopOptions {
   /**

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -112,7 +112,7 @@ describe('Consumer', () => {
         handleMessage,
         batchSize: 11
       });
-    }, 'SQS batchSize option must be between 1 and 10.');
+    }, 'batchSize must be between 1 and 10.');
   });
 
   it('requires the batchSize option to be greater than 0', () => {
@@ -123,7 +123,7 @@ describe('Consumer', () => {
         handleMessage,
         batchSize: -1
       });
-    }, 'SQS batchSize option must be between 1 and 10.');
+    }, 'batchSize must be between 1 and 10.');
   });
 
   it('requires visibilityTimeout to be set with heartbeatInterval', () => {
@@ -1240,26 +1240,6 @@ describe('Consumer', () => {
       );
     });
 
-    it('does not update the visibilityTimeout if the value is not a number', () => {
-      consumer = new Consumer({
-        region: REGION,
-        queueUrl: QUEUE_URL,
-        handleMessage,
-        visibilityTimeout: 60
-      });
-
-      const optionUpdatedListener = sandbox.stub();
-      consumer.on('option_updated', optionUpdatedListener);
-
-      assert.throws(() => {
-        consumer.updateOption('visibilityTimeout', 'value');
-      }, 'visibilityTimeout must be a number');
-
-      assert.equal(consumer.visibilityTimeout, 60);
-
-      sandbox.assert.notCalled(optionUpdatedListener);
-    });
-
     it('does not update the visibilityTimeout if the value is less than the heartbeatInterval', () => {
       consumer = new Consumer({
         region: REGION,
@@ -1292,19 +1272,6 @@ describe('Consumer', () => {
       sandbox.assert.calledWithMatch(optionUpdatedListener, 'batchSize', 4);
     });
 
-    it('does not update the batchSize if the value is not a number', () => {
-      const optionUpdatedListener = sandbox.stub();
-      consumer.on('option_updated', optionUpdatedListener);
-
-      assert.throws(() => {
-        consumer.updateOption('batchSize', 'value');
-      }, 'batchSize must be a number');
-
-      assert.equal(consumer.batchSize, 1);
-
-      sandbox.assert.notCalled(optionUpdatedListener);
-    });
-
     it('does not update the batchSize if the value is more than 10', () => {
       const optionUpdatedListener = sandbox.stub();
       consumer.on('option_updated', optionUpdatedListener);
@@ -1335,24 +1302,37 @@ describe('Consumer', () => {
       const optionUpdatedListener = sandbox.stub();
       consumer.on('option_updated', optionUpdatedListener);
 
-      consumer.updateOption('waitTimeSeconds', 56);
+      consumer.updateOption('waitTimeSeconds', 18);
 
-      assert.equal(consumer.waitTimeSeconds, 56);
+      assert.equal(consumer.waitTimeSeconds, 18);
 
       sandbox.assert.calledWithMatch(
         optionUpdatedListener,
         'waitTimeSeconds',
-        56
+        18
       );
     });
 
-    it('does not update the waitTimeSeconds if the value is not a number', () => {
+    it('does not update the batchSize if the value is less than 0', () => {
       const optionUpdatedListener = sandbox.stub();
       consumer.on('option_updated', optionUpdatedListener);
 
       assert.throws(() => {
-        consumer.updateOption('waitTimeSeconds', 'value');
-      }, 'waitTimeSeconds must be a number');
+        consumer.updateOption('waitTimeSeconds', -1);
+      }, 'waitTimeSeconds must be between 0 and 20.');
+
+      assert.equal(consumer.waitTimeSeconds, 20);
+
+      sandbox.assert.notCalled(optionUpdatedListener);
+    });
+
+    it('does not update the batchSize if the value is more than 20', () => {
+      const optionUpdatedListener = sandbox.stub();
+      consumer.on('option_updated', optionUpdatedListener);
+
+      assert.throws(() => {
+        consumer.updateOption('waitTimeSeconds', 27);
+      }, 'waitTimeSeconds must be between 0 and 20.');
 
       assert.equal(consumer.waitTimeSeconds, 20);
 

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -1281,6 +1281,84 @@ describe('Consumer', () => {
       sandbox.assert.notCalled(optionUpdatedListener);
     });
 
+    it('updates the batchSize option and emits an event', () => {
+      const optionUpdatedListener = sandbox.stub();
+      consumer.on('option_updated', optionUpdatedListener);
+
+      consumer.updateOption('batchSize', 4);
+
+      assert.equal(consumer.batchSize, 4);
+
+      sandbox.assert.calledWithMatch(optionUpdatedListener, 'batchSize', 4);
+    });
+
+    it('does not update the batchSize if the value is not a number', () => {
+      const optionUpdatedListener = sandbox.stub();
+      consumer.on('option_updated', optionUpdatedListener);
+
+      assert.throws(() => {
+        consumer.updateOption('batchSize', 'value');
+      }, 'batchSize must be a number');
+
+      assert.equal(consumer.batchSize, 1);
+
+      sandbox.assert.notCalled(optionUpdatedListener);
+    });
+
+    it('does not update the batchSize if the value is more than 10', () => {
+      const optionUpdatedListener = sandbox.stub();
+      consumer.on('option_updated', optionUpdatedListener);
+
+      assert.throws(() => {
+        consumer.updateOption('batchSize', 13);
+      }, 'batchSize must be between 1 and 10.');
+
+      assert.equal(consumer.batchSize, 1);
+
+      sandbox.assert.notCalled(optionUpdatedListener);
+    });
+
+    it('does not update the batchSize if the value is less than 1', () => {
+      const optionUpdatedListener = sandbox.stub();
+      consumer.on('option_updated', optionUpdatedListener);
+
+      assert.throws(() => {
+        consumer.updateOption('batchSize', 0);
+      }, 'batchSize must be between 1 and 10.');
+
+      assert.equal(consumer.batchSize, 1);
+
+      sandbox.assert.notCalled(optionUpdatedListener);
+    });
+
+    it('updates the waitTimeSeconds option and emits an event', () => {
+      const optionUpdatedListener = sandbox.stub();
+      consumer.on('option_updated', optionUpdatedListener);
+
+      consumer.updateOption('waitTimeSeconds', 56);
+
+      assert.equal(consumer.waitTimeSeconds, 56);
+
+      sandbox.assert.calledWithMatch(
+        optionUpdatedListener,
+        'waitTimeSeconds',
+        56
+      );
+    });
+
+    it('does not update the waitTimeSeconds if the value is not a number', () => {
+      const optionUpdatedListener = sandbox.stub();
+      consumer.on('option_updated', optionUpdatedListener);
+
+      assert.throws(() => {
+        consumer.updateOption('waitTimeSeconds', 'value');
+      }, 'waitTimeSeconds must be a number');
+
+      assert.equal(consumer.waitTimeSeconds, 20);
+
+      sandbox.assert.notCalled(optionUpdatedListener);
+    });
+
     it('throws an error for an unknown option', () => {
       consumer = new Consumer({
         region: REGION,


### PR DESCRIPTION
Resolves #396

This extends the update api further by allowing our users to also update the batchSize and waitTimeSeconds programatically, like we allowed for visibilityTimeout previously.

This uses the same API as what we previously added, just adds more available options and methods for those options.