### PR TITLE
feat: improving debugging capabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       "devDependencies": {
         "@cucumber/cucumber": "^8.10.0",
         "@types/chai": "^4.3.4",
-        "@types/debug": "^4.1.7",
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.11.18",
         "@types/sinon": "^10.0.13",
@@ -2301,15 +2300,6 @@
       "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
       "dev": true
     },
-    "node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dev": true,
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -2326,12 +2316,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
       "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
-      "dev": true
-    },
-    "node_modules/@types/ms": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -8314,15 +8298,6 @@
       "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
       "dev": true
     },
-    "@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dev": true,
-      "requires": {
-        "@types/ms": "*"
-      }
-    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -8339,12 +8314,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
       "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
-      "dev": true
-    },
-    "@types/ms": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "devDependencies": {
     "@cucumber/cucumber": "^8.10.0",
     "@types/chai": "^4.3.4",
-    "@types/debug": "^4.1.7",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.11.18",
     "@types/sinon": "^10.0.13",

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -15,7 +15,6 @@ import {
   ReceiveMessageCommandInput,
   ReceiveMessageCommandOutput
 } from '@aws-sdk/client-sqs';
-import Debug from 'debug';
 
 import {
   ConsumerOptions,
@@ -32,8 +31,7 @@ import {
 } from './errors';
 import { validateOption, assertOptions, hasMessages } from './validation';
 import { abortController } from './controllers';
-
-const debug = Debug('sqs-consumer');
+import { logger } from './logger';
 
 /**
  * [Usage](https://bbc.github.io/sqs-consumer/index.html#usage)
@@ -96,7 +94,7 @@ export class Consumer extends TypedEventEmitter {
    */
   public start(): void {
     if (this.stopped) {
-      debug('Starting consumer');
+      logger.debug('starting');
       this.stopped = false;
       this.emit('started');
       this.poll();
@@ -108,11 +106,11 @@ export class Consumer extends TypedEventEmitter {
    */
   public stop(options?: StopOptions): void {
     if (this.stopped) {
-      debug('Consumer was already stopped');
+      logger.debug('already_stopped');
       return;
     }
 
-    debug('Stopping consumer');
+    logger.debug('stopping');
     this.stopped = true;
 
     if (this.pollingTimeoutId) {
@@ -121,10 +119,8 @@ export class Consumer extends TypedEventEmitter {
     }
 
     if (options?.abort) {
-      debug('Aborting SQS requests');
-
+      logger.debug('aborting');
       abortController.abort();
-
       this.emit('aborted');
     }
 
@@ -148,8 +144,6 @@ export class Consumer extends TypedEventEmitter {
     value: ConsumerOptions[UpdatableOptions]
   ) {
     validateOption(option, value, this, true);
-
-    debug(`Updating the ${option} option to the value ${value}`);
 
     this[option] = value;
 
@@ -185,11 +179,13 @@ export class Consumer extends TypedEventEmitter {
    */
   private poll(): void {
     if (this.stopped) {
-      debug('Poll was called while consumer was stopped, cancelling poll...');
+      logger.debug('cancelling_poll', {
+        detail: 'Poll was called while consumer was stopped, cancelling poll...'
+      });
       return;
     }
 
-    debug('Polling for messages');
+    logger.debug('polling');
 
     let currentPollingTimeout = this.pollingWaitTimeMs;
     this.receiveMessage({
@@ -204,7 +200,10 @@ export class Consumer extends TypedEventEmitter {
       .catch((err) => {
         this.emitError(err);
         if (isConnectionError(err)) {
-          debug('There was an authentication error. Pausing before retrying.');
+          logger.debug('authentication_error', {
+            detail:
+              'There was an authentication error. Pausing before retrying.'
+          });
           currentPollingTimeout = this.authenticationErrorTimeout;
         }
         return;
@@ -246,11 +245,19 @@ export class Consumer extends TypedEventEmitter {
     response: ReceiveMessageCommandOutput
   ): Promise<void> {
     if (hasMessages(response)) {
+      const handlerProcessingDebugger = setInterval(() => {
+        logger.debug('handler_processing', {
+          detail: 'The handler is still processing the message(s)...'
+        });
+      }, 1000);
+
       if (this.handleMessageBatch) {
         await this.processMessageBatch(response.Messages);
       } else {
         await Promise.all(response.Messages.map(this.processMessage));
       }
+
+      clearInterval(handlerProcessingDebugger);
 
       this.emit('response_processed');
     } else if (response) {
@@ -287,7 +294,9 @@ export class Consumer extends TypedEventEmitter {
         await this.changeVisibilityTimeout(message, 0);
       }
     } finally {
-      clearInterval(heartbeatTimeoutId);
+      if (this.heartbeatInterval) {
+        clearInterval(heartbeatTimeoutId);
+      }
     }
   }
 
@@ -462,12 +471,13 @@ export class Consumer extends TypedEventEmitter {
    */
   private async deleteMessage(message: Message): Promise<void> {
     if (!this.shouldDeleteMessages) {
-      debug(
-        'Skipping message delete since shouldDeleteMessages is set to false'
-      );
+      logger.debug('skipping_delete', {
+        detail:
+          'Skipping message delete since shouldDeleteMessages is set to false'
+      });
       return;
     }
-    debug('Deleting message %s', message.MessageId);
+    logger.debug('deleting_message', { messageId: message.MessageId });
 
     const deleteParams: DeleteMessageCommandInput = {
       QueueUrl: this.queueUrl,
@@ -490,15 +500,15 @@ export class Consumer extends TypedEventEmitter {
    */
   private async deleteMessageBatch(messages: Message[]): Promise<void> {
     if (!this.shouldDeleteMessages) {
-      debug(
-        'Skipping message delete since shouldDeleteMessages is set to false'
-      );
+      logger.debug('skipping_delete', {
+        detail:
+          'Skipping message delete since shouldDeleteMessages is set to false'
+      });
       return;
     }
-    debug(
-      'Deleting messages %s',
-      messages.map((msg) => msg.MessageId).join(' ,')
-    );
+    logger.debug('deleting_messages', {
+      messageIds: messages.map((msg) => msg.MessageId)
+    });
 
     const deleteParams: DeleteMessageBatchCommandInput = {
       QueueUrl: this.queueUrl,

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -16,12 +16,8 @@ import {
   ReceiveMessageCommandOutput
 } from '@aws-sdk/client-sqs';
 
-import {
-  ConsumerOptions,
-  TypedEventEmitter,
-  StopOptions,
-  UpdatableOptions
-} from './types';
+import { ConsumerOptions, StopOptions, UpdatableOptions } from './types';
+import { TypedEventEmitter } from './emitter';
 import { autoBind } from './bind';
 import {
   SQSError,

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -1,0 +1,37 @@
+import { EventEmitter } from 'events';
+
+import { logger } from './logger';
+import { Events } from './types';
+
+export class TypedEventEmitter extends EventEmitter {
+  /**
+   * Trigger a listener on all emitted events
+   * @param event The name of the event to listen to
+   * @param listener A function to trigger when the event is emitted
+   */
+  on<E extends keyof Events>(
+    event: E,
+    listener: (...args: Events[E]) => void
+  ): this {
+    return super.on(event, listener);
+  }
+  /**
+   * Trigger a listener only once for an emitted event
+   * @param event The name of the event to listen to
+   * @param listener A function to trigger when the event is emitted
+   */
+  once<E extends keyof Events>(
+    event: E,
+    listener: (...args: Events[E]) => void
+  ): this {
+    return super.once(event, listener);
+  }
+  /**
+   * Emits an event with the provided arguments
+   * @param event The name of the event to emit
+   */
+  emit<E extends keyof Events>(event: E, ...args: Events[E]): boolean {
+    logger.debug(event, ...args);
+    return super.emit(event, ...args);
+  }
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,5 @@
+const debug = require('debug')('sqs-consumer');
+
+export const logger = {
+  debug
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 import { SQSClient, Message } from '@aws-sdk/client-sqs';
 import { EventEmitter } from 'events';
 
+import { logger } from './logger';
+
 export interface ConsumerOptions {
   /**
    * The SQS queue URL.
@@ -198,6 +200,7 @@ export class TypedEventEmitter extends EventEmitter {
    * @param event The name of the event to emit
    */
   emit<E extends keyof Events>(event: E, ...args: Events[E]): boolean {
+    logger.debug(event, ...args);
     return super.emit(event, ...args);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,4 @@
 import { SQSClient, Message } from '@aws-sdk/client-sqs';
-import { EventEmitter } from 'events';
-
-import { logger } from './logger';
 
 export interface ConsumerOptions {
   /**
@@ -170,39 +167,6 @@ export interface Events {
    * Fired when an option is updated
    */
   option_updated: [UpdatableOptions, ConsumerOptions[UpdatableOptions]];
-}
-
-export class TypedEventEmitter extends EventEmitter {
-  /**
-   * Trigger a listener on all emitted events
-   * @param event The name of the event to listen to
-   * @param listener A function to trigger when the event is emitted
-   */
-  on<E extends keyof Events>(
-    event: E,
-    listener: (...args: Events[E]) => void
-  ): this {
-    return super.on(event, listener);
-  }
-  /**
-   * Trigger a listener only once for an emitted event
-   * @param event The name of the event to listen to
-   * @param listener A function to trigger when the event is emitted
-   */
-  once<E extends keyof Events>(
-    event: E,
-    listener: (...args: Events[E]) => void
-  ): this {
-    return super.once(event, listener);
-  }
-  /**
-   * Emits an event with the provided arguments
-   * @param event The name of the event to emit
-   */
-  emit<E extends keyof Events>(event: E, ...args: Events[E]): boolean {
-    logger.debug(event, ...args);
-    return super.emit(event, ...args);
-  }
 }
 
 export type AWSError = {


### PR DESCRIPTION
Resolves #398, resolves #399

**Description:**

This PR extends the debuggers capabilities to both improve the logged messages but also add more debugging messages for when `.emit` is called and also a new message that sends while the user's handle message function is processing the message(s).

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

By adding these new methods, users will be able to better debug their applications and this primarily resolves issues where users are not listening to all events and also to allow users to determine if SQS Consumer is actually doing something during message processing, when it looks like it isn't.

**Code changes:**

- Created a new logger function that can be used across files
- Changed the messages that are sent in the debug logs to be simpler and to line up with other event names.
- Added a debug logging event to the `.emit` event so all emitted events are sent through the debugger as well, meaning that the app doesn't require all of the listeners to properly debug events.
- Added a debug message that will send periodically while the user's handle message function is processing the message(s)
- Moved the typed emitter to its own file as it makes more sense outside of types

