### PR TITLE
chore(ci): start testing against node 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Part of https://github.com/bbc/sqs-consumer/issues/413 to set up testing against Node 20 before we move to support node 18 and 20 only.