### PR TITLE
feat: add pre and post receive message callbacks

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -103,6 +103,22 @@ export interface ConsumerOptions {
    * the successful messages only.
    */
   handleMessageBatch?(messages: Message[]): Promise<Message[] | void>;
+  /**
+   * An `async` function (or function that returns a `Promise`) to be called right
+   * before the SQS Client sends a receive message command.
+   *
+   * This function is usefull if SQS Client module exports have been modified, for
+   * example to add middlewares.
+   */
+  preReceiveMessageCallback?(): Promise<void>;
+  /**
+   * An `async` function (or function that returns a `Promise`) to be called right
+   * after the SQS Client sends a receive message command.
+   *
+   * This function is usefull if SQS Client module exports have been modified, for
+   * example to add middlewares.
+   */
+  postReceiveMessageCallback?(): Promise<void>;
 }
 
 export type UpdatableOptions =

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -480,7 +480,7 @@ describe('Consumer', () => {
     });
 
     it('calls the preReceiveMessageCallback and postReceiveMessageCallback function before receiving a message', async () => {
-      let callbackCalls = 0
+      let callbackCalls = 0;
 
       consumer = new Consumer({
         queueUrl: QUEUE_URL,
@@ -489,10 +489,10 @@ describe('Consumer', () => {
         sqs,
         authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
         preReceiveMessageCallback: async () => {
-          callbackCalls++
+          callbackCalls++;
         },
         postReceiveMessageCallback: async () => {
-          callbackCalls++
+          callbackCalls++;
         }
       });
 
@@ -501,7 +501,7 @@ describe('Consumer', () => {
       consumer.stop();
 
       assert.equal(callbackCalls, 2);
-    })
+    });
 
     it('deletes the message when the handleMessage function is called', async () => {
       handleMessage.resolves();

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -479,6 +479,30 @@ describe('Consumer', () => {
       sandbox.assert.calledWith(handleMessage, response.Messages[0]);
     });
 
+    it('calls the preReceiveMessageCallback and postReceiveMessageCallback function before receiving a message', async () => {
+      let callbackCalls = 0
+
+      consumer = new Consumer({
+        queueUrl: QUEUE_URL,
+        region: REGION,
+        handleMessage,
+        sqs,
+        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
+        preReceiveMessageCallback: async () => {
+          callbackCalls++
+        },
+        postReceiveMessageCallback: async () => {
+          callbackCalls++
+        }
+      });
+
+      consumer.start();
+      await pEvent(consumer, 'message_processed');
+      consumer.stop();
+
+      assert.equal(callbackCalls, 2);
+    })
+
     it('deletes the message when the handleMessage function is called', async () => {
       handleMessage.resolves();
 


### PR DESCRIPTION
Resolves #17 

**Description:**
This adds an option to hook your code just before and right after the SQS Client sends the `ReceiveMessageCommand`.

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

This is a change that is required if you'd like to use [OpenTelemetry](https://opentelemetry.io) in an organised way with their official js instrumentation for AWS SDK.

The way open telemetry works is that it creates `Traces` for what's going on in a distributed system. Think of them as a request or single SQS message processing. Those traces are then broken down into `Spans` later on for things like db communication, http request etc. Usually the top level span you'd want to create in a trace is one that is representing the consumer service. And that is where the problem kicks in. The way that OpenTelemetry AWS SDK Instrumentation works is that it [patches the module exports of the SQS Client](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/a8c225d2febcac561a70ca586d3efd5a84f9f3fa/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts)

By doing so it is able to wrap the SQS communication of `ReceiveMessageCommand` into a `Segment` of its own. So this way when you visualise your telemetry you are stuck with having the SQS queue as a service instead of the actual consumer of the SQS queue. Hooking up on the `handleMessage` function in order to wrap the top level segment is a bit too late since the `ReceiveMessageCommand` has been already executed at this point.

**Code changes:**

- _Added optional callbacks to the `ConsumerOptions`_

---

**Checklist:**

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
