### PR TITLE
Allow consumers stopped with abort: true to be restarted

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -104,7 +104,8 @@ export class Consumer extends TypedEventEmitter {
    */
   private get sqsSendOptions(): { abortSignal: AbortSignal } {
     return {
-      // return the current abortController signal or a generic not aborted signal
+      // return the current abortController signal or a fresh signal that has not been aborted.
+      // This effectively defaults the signal sent to the AWS SDK to not aborted
       abortSignal: this.abortController?.signal || new AbortController().signal
     };
   }

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -104,7 +104,8 @@ export class Consumer extends TypedEventEmitter {
    */
   private get sqsSendOptions(): { abortSignal: AbortSignal } {
     return {
-      abortSignal: this.abortController?.signal
+      // return the current abortController signal or a generic not aborted signal
+      abortSignal: this.abortController?.signal || new AbortController().signal
     };
   }
 

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -26,7 +26,6 @@ import {
   isConnectionError
 } from './errors';
 import { validateOption, assertOptions, hasMessages } from './validation';
-import { abortController } from './controllers';
 import { logger } from './logger';
 
 /**
@@ -50,6 +49,7 @@ export class Consumer extends TypedEventEmitter {
   private authenticationErrorTimeout: number;
   private pollingWaitTimeMs: number;
   private heartbeatInterval: number;
+  public abortController: AbortController;
 
   constructor(options: ConsumerOptions) {
     super();
@@ -90,11 +90,22 @@ export class Consumer extends TypedEventEmitter {
    */
   public start(): void {
     if (this.stopped) {
+      // Create a new abort controller each time the consumer is started
+      this.abortController = new AbortController();
       logger.debug('starting');
       this.stopped = false;
       this.emit('started');
       this.poll();
     }
+  }
+
+  /**
+   * A reusable options object for sqs.send that's used to avoid duplication.
+   */
+  private get sqsSendOptions(): { abortSignal: AbortSignal } {
+    return {
+      abortSignal: this.abortController?.signal
+    };
   }
 
   /**
@@ -116,7 +127,7 @@ export class Consumer extends TypedEventEmitter {
 
     if (options?.abort) {
       logger.debug('aborting');
-      abortController.abort();
+      this.abortController.abort();
       this.emit('aborted');
     }
 
@@ -162,13 +173,6 @@ export class Consumer extends TypedEventEmitter {
       this.emit('processing_error', err, message);
     }
   }
-
-  /**
-   * A reusable options object for sqs.send that's used to avoid duplication.
-   */
-  private sqsSendOptions = {
-    abortSignal: abortController.signal
-  };
 
   /**
    * Poll for new messages from SQS

--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -1,1 +1,0 @@
-export const abortController = new AbortController();

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -12,7 +12,6 @@ import * as pEvent from 'p-event';
 
 import { AWSError } from '../../src/types';
 import { Consumer } from '../../src/consumer';
-import { abortController } from '../../src/controllers';
 import { logger } from '../../src/logger';
 
 const sandbox = sinon.createSandbox();
@@ -168,6 +167,32 @@ describe('Consumer', () => {
   });
 
   describe('.start', () => {
+    it('uses the correct abort signal', async () => {
+      sqs.send
+        .withArgs(mockReceiveMessage)
+        .resolves(new Promise((res) => setTimeout(res, 100)));
+
+      // Starts and abort is false
+      consumer.start();
+      assert.isFalse(sqs.send.lastCall.lastArg.abortSignal.aborted);
+
+      // normal stop without an abort and abort is false
+      consumer.stop();
+      assert.isFalse(sqs.send.lastCall.lastArg.abortSignal.aborted);
+
+      // Starts and abort is false
+      consumer.start();
+      assert.isFalse(sqs.send.lastCall.lastArg.abortSignal.aborted);
+
+      // Stop with abort and abort is true
+      consumer.stop({ abort: true });
+      assert.isTrue(sqs.send.lastCall.lastArg.abortSignal.aborted);
+
+      // Starts and abort is false
+      consumer.start();
+      assert.isFalse(sqs.send.lastCall.lastArg.abortSignal.aborted);
+    });
+
     it('fires an event when the consumer is started', async () => {
       const handleStart = sandbox.stub().returns(null);
 
@@ -1303,7 +1328,6 @@ describe('Consumer', () => {
     it('aborts requests when the abort param is true', async () => {
       const handleStop = sandbox.stub().returns(null);
       const handleAbort = sandbox.stub().returns(null);
-      const abortControllerAbort = sandbox.stub(abortController, 'abort');
 
       consumer.on('stopped', handleStop);
       consumer.on('aborted', handleAbort);
@@ -1313,8 +1337,8 @@ describe('Consumer', () => {
 
       await clock.runAllAsync();
 
+      assert.isTrue(consumer.abortController.signal.aborted);
       sandbox.assert.calledOnce(handleMessage);
-      sandbox.assert.calledOnce(abortControllerAbort);
       sandbox.assert.calledOnce(handleAbort);
       sandbox.assert.calledOnce(handleStop);
     });


### PR DESCRIPTION
Resolves https://github.com/bbc/sqs-consumer/issues/389

**Description:**
This bug was originally closed, but I've been running into a related issue. Basically we want to start and stop a consumer based on a feature flag while using the `abort` option on `.stop`. The singleton `AbortController` makes it impossible to restart an aborted consumer, even if the consumer is recreated. This results in the abort signal persisting and being sent into any following AWS SDK calls.

This PR creates a new `AbortController` each time the consumer is started, which results in a fresh abort signal and allows the consumer to restart. I've also removed the previous `controller.ts` file as it's no longer used.

I've also added an associated test that fails without these changes that demonstrates how the abort signal is being passed to the AWS SDK `.send` method. Thanks!

**Type of change:**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
_A simple explanation of what the problem is and how this PR solves it_

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

**Checklist:**

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
