### PR TITLE
chore: clarify how acknowledgement works

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ app.start();
     - It's also important to await any processing that you are doing to ensure that messages are processed one at a time.
 - By default, messages that are sent to the `handleMessage` and `handleMessageBatch` functions will be considered as processed if they return without an error.
     - To acknowledge individual messages, please return the message that you want to acknowledge if you are using `handleMessage` or the messages for `handleMessageBatch`.
-        - To also note, returning an object or an array will be considered an acknowledgement of no message(s) and will result in no messages being deleted.
+        - To note, returning an object or an array will be considered an acknowledgement of no message(s) and will result in no messages being deleted.
+        - By default, if an object or an array is not returned, all messages will be acknowledged.
 - Messages are deleted from the queue once the handler function has completed successfully (the above items should also be taken into account).
 
 ### Credentials

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ app.start();
 - The queue is polled continuously for messages using [long polling](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html).
 - Throwing an error (or returning a rejected promise) from the handler function will cause the message to be left on the queue. An [SQS redrive policy](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html) can be used to move messages that cannot be processed to a dead letter queue.
 - By default messages are processed one at a time – a new message won't be received until the first one has been processed. To process messages in parallel, use the `batchSize` option [detailed below](#options).
-    - It's also important to await any processing that you are doing to ensure that messages are processed one at a time.
+  - It's also important to await any processing that you are doing to ensure that messages are processed one at a time.
 - By default, messages that are sent to the `handleMessage` and `handleMessageBatch` functions will be considered as processed if they return without an error.
-    - To acknowledge individual messages, please return the message that you want to acknowledge if you are using `handleMessage` or the messages for `handleMessageBatch`.
-        - To note, returning an object or an array will be considered an acknowledgement of no message(s) and will result in no messages being deleted.
-        - By default, if an object or an array is not returned, all messages will be acknowledged.
+  - To acknowledge individual messages, please return the message that you want to acknowledge if you are using `handleMessage` or the messages for `handleMessageBatch`.
+    - To note, returning an object or an array will be considered an acknowledgement of no message(s) and will result in no messages being deleted.
+    - By default, if an object or an array is not returned, all messages will be acknowledged.
 - Messages are deleted from the queue once the handler function has completed successfully (the above items should also be taken into account).
 
 ### Credentials

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ app.start();
 - The queue is polled continuously for messages using [long polling](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html).
 - Throwing an error (or returning a rejected promise) from the handler function will cause the message to be left on the queue. An [SQS redrive policy](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html) can be used to move messages that cannot be processed to a dead letter queue.
 - By default messages are processed one at a time – a new message won't be received until the first one has been processed. To process messages in parallel, use the `batchSize` option [detailed below](#options).
+    - It's also important to await any processing that you are doing to ensure that messages are processed one at a time.
 - By default, messages that are sent to the `handleMessage` and `handleMessageBatch` functions will be considered as processed if they return without an error.
     - To acknowledge individual messages, please return the message that you want to acknowledge if you are using `handleMessage` or the messages for `handleMessageBatch`.
         - To also note, returning an object or an array will be considered an acknowledgement of no message(s) and will result in no messages being deleted.
-    - It's also important to await any processing that you are doing to ensure that messages are processed one at a time.
 - Messages are deleted from the queue once the handler function has completed successfully (the above items should also be taken into account).
 
 ### Credentials

--- a/README.md
+++ b/README.md
@@ -50,10 +50,13 @@ app.start();
 ```
 
 - The queue is polled continuously for messages using [long polling](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html).
-- Messages are deleted from the queue once the handler function has completed successfully.
 - Throwing an error (or returning a rejected promise) from the handler function will cause the message to be left on the queue. An [SQS redrive policy](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html) can be used to move messages that cannot be processed to a dead letter queue.
 - By default messages are processed one at a time – a new message won't be received until the first one has been processed. To process messages in parallel, use the `batchSize` option [detailed below](#options).
-- By default, messages that are sent to the `handleMessage` and `handleMessageBatch` functions will be considered as processed if they return without an error. To acknowledge individual messages, please return the message that you want to acknowledge if you are using `handleMessage` or the messages for `handleMessageBatch`. It's also important to await any processing that you are doing to ensure that messages are processed one at a time.
+- By default, messages that are sent to the `handleMessage` and `handleMessageBatch` functions will be considered as processed if they return without an error.
+    - To acknowledge individual messages, please return the message that you want to acknowledge if you are using `handleMessage` or the messages for `handleMessageBatch`.
+        - To also note, returning an object or an array will be considered an acknowledgement of no message(s) and will result in no messages being deleted.
+    - It's also important to await any processing that you are doing to ensure that messages are processed one at a time.
+- Messages are deleted from the queue once the handler function has completed successfully (the above items should also be taken into account).
 
 ### Credentials
 


### PR DESCRIPTION
In response to #443, this updates the readme in an attempt to further clarify how acknowledgement and deletion of messages works.

It also restructures the documentation to ensure that the details are read in the correct order of operation.