### PR TITLE
feat: adding a flag to force consumer to always acknowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ app.start();
 - By default, messages that are sent to the `handleMessage` and `handleMessageBatch` functions will be considered as processed if they return without an error.
   - To acknowledge individual messages, please return the message that you want to acknowledge if you are using `handleMessage` or the messages for `handleMessageBatch`.
     - To note, returning an empty object or an empty array will be considered an acknowledgement of no message(s) and will result in no messages being deleted.
-    - By default, if an object or an array is not returned, all messages will be acknowledged.
+    - By default, if an object or an array is not returned, all messages will be acknowledged. If you would like to change this behaviour, please use the `alwaysAcknowledge` option [detailed below](#options).
 - Messages are deleted from the queue once the handler function has completed successfully (the above items should also be taken into account).
 
 ### Credentials

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,14 @@ export interface ConsumerOptions {
    */
   shouldDeleteMessages?: boolean;
   /**
+   * By default, the consumer will treat an empty object or array from either of the
+   * handlers as a acknowledgement of no messages and will not delete those messages as
+   * a result. Set this to `true` to always acknowledge all messages no matter the returned
+   * value.
+   * @defaultvalue `false`
+   */
+  alwaysAcknowledge?: boolean;
+  /**
    * An `async` function (or function that returns a `Promise`) to be called whenever
    * a message is received.
    *


### PR DESCRIPTION
Resolves #443

**Description:**

As described in the issue, when we added acknowledgement some time ago, we did so in a way that broke the expected behaviour from users by changing the internal expectation of how the handlers should return and what happens as a result of that return.

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

While we can't undo this breaking change, and we can't reverse this new default behaviour (as that would be another breaking change), this change goes some way to resolve the issue by adding a feature flag that allows users to change this default behaviour, forcing the consumer to always acknowledge all messages, no matter the returned data from the handlers.

**Code changes:**

- Added a new options named `alwaysAcknowledge`
- The new option will default to false to maintain the current behaviour
- If set to true, it will force the consumer to always return all message(s) from the execution, no matter what is returned from the handlers.
- Updated the documentation to note that this option exists.

