### PR TITLE
feat: adding the ability to execute the consumer concurrently

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * The current polling status of the consumer.
+ */
+export enum POLLING_STATUS {
+  ACTIVE,
+  WAITING,
+  INACTIVE,
+  READY
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,5 +5,5 @@ export enum POLLING_STATUS {
   ACTIVE,
   WAITING,
   INACTIVE,
-  READY
+  READY,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,11 @@ export interface ConsumerOptions {
    */
   batchSize?: number;
   /**
+   * The number of messages (or batches if `handleMessageBatch` is set) to
+   * process concurrently.
+   */
+  concurrency?: number;
+  /**
    * The duration (in seconds) that the received messages are hidden from subsequent
    * retrieve requests after being retrieved by a ReceiveMessage request.
    */

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -20,6 +20,11 @@ function validateOption(
         throw new Error('batchSize must be between 1 and 10.');
       }
       break;
+    case 'concurrency':
+      if (value < 1) {
+        throw new Error('concurrency must be greater than 0.');
+      }
+      break;
     case 'heartbeatInterval':
       if (
         !allOptions.visibilityTimeout ||
@@ -74,6 +79,9 @@ function assertOptions(options: ConsumerOptions): void {
 
   if (options.batchSize) {
     validateOption('batchSize', options.batchSize, options);
+  }
+  if (options.concurrency) {
+    validateOption('concurrency', options.concurrency, options);
   }
   if (options.heartbeatInterval) {
     validateOption('heartbeatInterval', options.heartbeatInterval, options);

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -128,6 +128,17 @@ describe('Consumer', () => {
       }, 'batchSize must be between 1 and 10.');
     });
 
+    it('requires the concurrency option to be greater than 0', () => {
+      assert.throws(() => {
+        new Consumer({
+          region: REGION,
+          queueUrl: QUEUE_URL,
+          handleMessage,
+          concurrency: 0
+        });
+      }, 'concurrency must be greater than 0.');
+    });
+
     it('requires visibilityTimeout to be set with heartbeatInterval', () => {
       assert.throws(() => {
         new Consumer({
@@ -1567,6 +1578,30 @@ describe('Consumer', () => {
       }, 'batchSize must be between 1 and 10.');
 
       assert.equal(consumer.batchSize, 1);
+
+      sandbox.assert.notCalled(optionUpdatedListener);
+    });
+
+    it('updates the concurrency option and emits an event', () => {
+      const optionUpdatedListener = sandbox.stub();
+      consumer.on('option_updated', optionUpdatedListener);
+
+      consumer.updateOption('concurrency', 4);
+
+      assert.equal(consumer.concurrency, 4);
+
+      sandbox.assert.calledWithMatch(optionUpdatedListener, 'concurrency', 4);
+    });
+
+    it('does not update the concurrency if the value is less than 1', () => {
+      const optionUpdatedListener = sandbox.stub();
+      consumer.on('option_updated', optionUpdatedListener);
+
+      assert.throws(() => {
+        consumer.updateOption('concurrency', 0);
+      }, 'concurrency must be greater than 0.');
+
+      assert.equal(consumer.concurrency, 1);
 
       sandbox.assert.notCalled(optionUpdatedListener);
     });


### PR DESCRIPTION
> **Note:**
> This is complete discovery currently, it is not expected that it will work, nor does it...
> Please do not attempt to use it.

Resolves #397

**Description:**

The aim of this PR is to add the ability to execute SQS Consumer concurrently, meaning that it will keep triggering polls past the batch size and while other messages are being processed, up to a concurrent limit.

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

Currently, SQS Consumer restricts the amount of messages that can be processed to the batch size from AWS, this means that users are limited to processing a maximum of 10 messages at a time.

**Code changes:**

- Added a new constants file that contains an enum for polling status values
- Added a new option for `concurrency` that allows the user to configure the limits
- Split the poll timeout functionality into a new function so it can be called from multiple places
- Added tracking for the amount of concurrent executions
- Adjusted the logic to queue a poll while messages are processing.
- Updated status method to return concurrency and polling status

- [ ] Add a new timeout value option for the amount of time to wait when the concurrent count has been reached (currently this is the normal timeout count, which may be wrong for some users)
- [ ] Add unit/integration tests
- [ ] Check that this works in the real world with a canary release (while still in PR)
- [ ] Our users don't have concurrency right now, how might this affect them? This is most likely a breaking change any way, but we should check that there are no negative effects.

