### PR TITLE
chore: updating `attributeNames` type docs

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,7 @@ export interface ConsumerOptions {
    */
   queueUrl: string;
   /**
-   * List of queue attributes to retrieve (i.e.
-   * `['All', 'ApproximateFirstReceiveTimestamp', 'ApproximateReceiveCount']`).
+   * List of queue attributes to retrieve, see [AWS docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-sqs/Variable/QueueAttributeName/).
    * @defaultvalue `[]`
    */
   attributeNames?: QueueAttributeName[];


### PR DESCRIPTION
Resolves #451

**Description:**

Previously, we listed a number of example values for the `attributeNames` name option, which did not entirely line up with the types that AWS was actually providing through `QueueAttributeName`.

**Type of change:**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

To ensure that users aren't confused by the type provided by SQS Consumer.

**Code changes:**

- Removed the existing examples and replaced them with a link to: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-sqs/Variable/QueueAttributeName/
