### PR TITLE
feat: Wait for msgs to be processed before emitting stopped

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,13 @@ By default, the value of `abort` is set to `false` which means pre existing requ
 
 `consumer.stop({ abort: true })`
 
-Optionally, you can wait for any in flight messages to complete before stopping the consumer by passing `waitForInFlightMessages: true` in the options object.
+Optionally, you can wait for in flight messages to complete before stopping the consumer
+by passing a timeout `waitForInFlightMessagesMs` in the options object.
 
-`consumer.stop({ waitForInFlightMessages: true, waitTimeMs: 30000 });`
+This will allow the final in-progress `poll` to complete as well as any messages received during that poll.
+Be sure to account for the polling `waitTimeSeconds` plus any message processing time you want to allow.
+
+`consumer.stop({ waitForInFlightMessagesMs: 30000 });`
 
 ### `consumer.isRunning`
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ By default, the value of `abort` is set to `false` which means pre existing requ
 
 `consumer.stop({ abort: true })`
 
+Optionally, you can wait for any in flight messages to complete before stopping the consumer by passing `waitForInFlightMessages: true` in the options object.
+
+`consumer.stop({ waitForInFlightMessages: true, waitTimeMs: 30000 });`
+
 ### `consumer.isRunning`
 
 Returns the current polling state of the consumer: `true` if it is actively polling, `false` if it is not.

--- a/README.md
+++ b/README.md
@@ -125,14 +125,6 @@ By default, the value of `abort` is set to `false` which means pre existing requ
 
 `consumer.stop({ abort: true })`
 
-Optionally, you can wait for in flight messages to complete before stopping the consumer
-by passing a timeout `waitForInFlightMessagesMs` in the options object.
-
-This will allow the final in-progress `poll` to complete as well as any messages received during that poll.
-Be sure to account for the polling `waitTimeSeconds` plus any message processing time you want to allow.
-
-`consumer.stop({ waitForInFlightMessagesMs: 30000 });`
-
 ### `consumer.isRunning`
 
 Returns the current polling state of the consumer: `true` if it is actively polling, `false` if it is not.

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -54,6 +54,7 @@ export class Consumer extends TypedEventEmitter {
   private waitTimeSeconds: number;
   private authenticationErrorTimeout: number;
   private pollingWaitTimeMs: number;
+  private pollingCompleteWaitTimeMs: number;
   private heartbeatInterval: number;
   private isPolling: boolean;
   public abortController: AbortController;
@@ -78,6 +79,7 @@ export class Consumer extends TypedEventEmitter {
     this.authenticationErrorTimeout =
       options.authenticationErrorTimeout ?? 10000;
     this.pollingWaitTimeMs = options.pollingWaitTimeMs ?? 0;
+    this.pollingCompleteWaitTimeMs = options.pollingCompleteWaitTimeMs ?? 0;
     this.shouldDeleteMessages = options.shouldDeleteMessages ?? true;
     this.alwaysAcknowledge = options.alwaysAcknowledge ?? false;
     this.sqs =
@@ -143,9 +145,9 @@ export class Consumer extends TypedEventEmitter {
       this.emit('aborted');
     }
 
-    if (options?.waitForInFlightMessagesMs > 0) {
+    if (this.pollingCompleteWaitTimeMs > 0) {
       this.waitForInFlightMessagesToComplete(
-        options.waitForInFlightMessagesMs
+        this.pollingCompleteWaitTimeMs
       ).then(() => {
         this.emit('stopped');
       });

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -146,9 +146,7 @@ export class Consumer extends TypedEventEmitter {
     }
 
     if (this.pollingCompleteWaitTimeMs > 0) {
-      this.waitForInFlightMessagesToComplete(
-        this.pollingCompleteWaitTimeMs
-      ).then(() => {
+      this.waitForPollingToComplete(this.pollingCompleteWaitTimeMs).then(() => {
         this.emit('stopped');
       });
     } else {
@@ -161,9 +159,7 @@ export class Consumer extends TypedEventEmitter {
    * @param {number} waitTimeoutMs
    * @private
    */
-  private async waitForInFlightMessagesToComplete(
-    waitTimeoutMs: number
-  ): Promise<void> {
+  private async waitForPollingToComplete(waitTimeoutMs: number): Promise<void> {
     const startedAt = Date.now();
     while (this.isPolling) {
       if (Date.now() - startedAt > waitTimeoutMs) {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -57,7 +57,7 @@ export class Consumer extends TypedEventEmitter {
   private pollingCompleteWaitTimeMs: number;
   private heartbeatInterval: number;
   private isPolling: boolean;
-  private beganWaitingForStop: number;
+  private stopRequestedAtTimestamp: number;
   public abortController: AbortController;
 
   constructor(options: ConsumerOptions) {
@@ -146,7 +146,7 @@ export class Consumer extends TypedEventEmitter {
       this.emit('aborted');
     }
 
-    this.beganWaitingForStop = Date.now();
+    this.stopRequestedAtTimestamp = Date.now();
     this.waitForPollingToComplete();
   }
 
@@ -161,7 +161,8 @@ export class Consumer extends TypedEventEmitter {
     }
 
     const exceededTimeout =
-      Date.now() - this.beganWaitingForStop > this.pollingCompleteWaitTimeMs;
+      Date.now() - this.stopRequestedAtTimestamp >
+      this.pollingCompleteWaitTimeMs;
     if (exceededTimeout) {
       logger.debug('waiting_for_polling_to_complete_timeout_exceeded');
       this.emit('stopped');

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,18 +143,11 @@ export interface StopOptions {
   abort?: boolean;
 
   /**
-   * Default to `false`, if you want the stop action to wait for in-flight messages
-   * to be processed before emitting 'stopped' set this to `true`.
-   * @defaultvalue `false`
+   * If you want the stop action to wait for the final poll to complete and in-flight messages
+   * to be processed before emitting 'stopped' set this to the max amount of time to wait.
+   * @defaultvalue `undefined`
    */
-  waitForInFlightMessages?: boolean;
-
-  /**
-   * if `waitForInFlightMessages` is set to `true`, this option will be used to
-   * determine how long to wait for in-flight messages to be processed before
-   * emitting 'stopped'.
-   */
-  waitTimeoutMs?: number;
+  waitForInFlightMessagesMs?: number;
 }
 
 export interface Events {

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,20 @@ export interface StopOptions {
    * @defaultvalue `false`
    */
   abort?: boolean;
+
+  /**
+   * Default to `false`, if you want the stop action to wait for in-flight messages
+   * to be processed before emitting 'stopped' set this to `true`.
+   * @defaultvalue `false`
+   */
+  waitForInFlightMessages?: boolean;
+
+  /**
+   * if `waitForInFlightMessages` is set to `true`, this option will be used to
+   * determine how long to wait for in-flight messages to be processed before
+   * emitting 'stopped'.
+   */
+  waitTimeoutMs?: number;
 }
 
 export interface Events {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,12 @@ export interface ConsumerOptions {
    */
   pollingWaitTimeMs?: number;
   /**
+   * If you want the stop action to wait for the final poll to complete and in-flight messages
+   * to be processed before emitting 'stopped' set this to the max amount of time to wait.
+   * @defaultvalue `0`
+   */
+  pollingCompleteWaitTimeMs?: number;
+  /**
    * If true, sets the message visibility timeout to 0 after a `processing_error`.
    * @defaultvalue `false`
    */
@@ -141,13 +147,6 @@ export interface StopOptions {
    * @defaultvalue `false`
    */
   abort?: boolean;
-
-  /**
-   * If you want the stop action to wait for the final poll to complete and in-flight messages
-   * to be processed before emitting 'stopped' set this to the max amount of time to wait.
-   * @defaultvalue `undefined`
-   */
-  waitForInFlightMessagesMs?: number;
 }
 
 export interface Events {

--- a/test/features/gracefulShutdown.feature
+++ b/test/features/gracefulShutdown.feature
@@ -1,0 +1,6 @@
+Feature: Graceful shutdown
+
+  Scenario: Several messages in flight
+    Given Several messages are sent to the SQS queue
+    Then the application is stopped while messages are in flight
+    Then the in-flight messages should be processed before stopped is emitted

--- a/test/features/step_definitions/gracefulShutdown.js
+++ b/test/features/step_definitions/gracefulShutdown.js
@@ -29,7 +29,7 @@ Given('Several messages are sent to the SQS queue', async () => {
 Then('the application is stopped while messages are in flight', async () => {
   consumer.start();
 
-  consumer.stop({ waitForInFlightMessagesMs: 5000 });
+  consumer.stop();
 
   assert.strictEqual(consumer.isRunning, false);
 });

--- a/test/features/step_definitions/gracefulShutdown.js
+++ b/test/features/step_definitions/gracefulShutdown.js
@@ -1,0 +1,56 @@
+const { Given, Then, After } = require('@cucumber/cucumber');
+const assert = require('assert');
+const { PurgeQueueCommand } = require('@aws-sdk/client-sqs');
+const pEvent = require('p-event');
+
+const { consumer } = require('../utils/consumer/gracefulShutdown');
+const { producer } = require('../utils/producer');
+const { sqs, QUEUE_URL } = require('../utils/sqs');
+
+Given('Several messages are sent to the SQS queue', async () => {
+  const params = {
+    QueueUrl: QUEUE_URL
+  };
+  const command = new PurgeQueueCommand(params);
+  const response = await sqs.send(command);
+
+  assert.strictEqual(response['$metadata'].httpStatusCode, 200);
+
+  const size = await producer.queueSize();
+  assert.strictEqual(size, 0);
+
+  await producer.send(['msg1', 'msg2', 'msg3']);
+
+  const size2 = await producer.queueSize();
+
+  assert.strictEqual(size2, 3);
+});
+
+Then('the application is stopped while messages are in flight', async () => {
+  consumer.start();
+
+  consumer.stop({ waitForInFlightMessagesMs: 5000 });
+
+  assert.strictEqual(consumer.isRunning, false);
+});
+
+Then(
+  'the in-flight messages should be processed before stopped is emitted',
+  async () => {
+    let numProcessed = 0;
+    consumer.on('message_processed', () => {
+      numProcessed++;
+    });
+
+    await pEvent(consumer, 'stopped');
+
+    assert.strictEqual(numProcessed, 3);
+
+    const size = await producer.queueSize();
+    assert.strictEqual(size, 0);
+  }
+);
+
+After(() => {
+  return consumer.stop();
+});

--- a/test/features/utils/consumer/gracefulShutdown.js
+++ b/test/features/utils/consumer/gracefulShutdown.js
@@ -6,6 +6,7 @@ const consumer = Consumer.create({
   queueUrl: QUEUE_URL,
   sqs,
   pollingWaitTimeMs: 1000,
+  pollingCompleteWaitTimeMs: 5000,
   batchSize: 10,
   handleMessage: async (message) => {
     await new Promise((resolve) => setTimeout(resolve, 100));

--- a/test/features/utils/consumer/gracefulShutdown.js
+++ b/test/features/utils/consumer/gracefulShutdown.js
@@ -1,0 +1,16 @@
+const { Consumer } = require('../../../../dist/consumer');
+
+const { QUEUE_URL, sqs } = require('../sqs');
+
+const consumer = Consumer.create({
+  queueUrl: QUEUE_URL,
+  sqs,
+  pollingWaitTimeMs: 1000,
+  batchSize: 10,
+  handleMessage: async (message) => {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    return message;
+  }
+});
+
+exports.consumer = consumer;

--- a/test/features/utils/consumer/gracefulShutdown.js
+++ b/test/features/utils/consumer/gracefulShutdown.js
@@ -9,7 +9,7 @@ const consumer = Consumer.create({
   pollingCompleteWaitTimeMs: 5000,
   batchSize: 10,
   handleMessage: async (message) => {
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 1500));
     return message;
   }
 });

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -1482,7 +1482,7 @@ describe('Consumer', () => {
       sandbox.assert.calledOnce(handleStop);
     });
 
-    it('waits for in-flight messages before emitting stopped (no timeout)', async () => {
+    it('waits for in-flight messages before emitting stopped (within timeout)', async () => {
       const handleStop = sandbox.stub().returns(null);
       const handleResponseProcessed = sandbox.stub().returns(null);
 
@@ -1504,7 +1504,7 @@ describe('Consumer', () => {
 
       consumer.start();
       await clock.nextAsync();
-      consumer.stop({ waitForInFlightMessages: true });
+      consumer.stop({ waitForInFlightMessagesMs: 5000 });
 
       await clock.runAllAsync();
 
@@ -1540,7 +1540,7 @@ describe('Consumer', () => {
 
       consumer.start();
       await clock.nextAsync();
-      consumer.stop({ waitForInFlightMessages: true, waitTimeoutMs: 500 });
+      consumer.stop({ waitForInFlightMessagesMs: 500 });
 
       await clock.runAllAsync();
 

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -1496,6 +1496,7 @@ describe('Consumer', () => {
         region: REGION,
         handleMessage,
         sqs,
+        pollingCompleteWaitTimeMs: 5000,
         authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT
       });
 
@@ -1504,7 +1505,7 @@ describe('Consumer', () => {
 
       consumer.start();
       await clock.nextAsync();
-      consumer.stop({ waitForInFlightMessagesMs: 5000 });
+      consumer.stop();
 
       await clock.runAllAsync();
 
@@ -1532,6 +1533,7 @@ describe('Consumer', () => {
         region: REGION,
         handleMessage,
         sqs,
+        pollingCompleteWaitTimeMs: 500,
         authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT
       });
 
@@ -1540,7 +1542,7 @@ describe('Consumer', () => {
 
       consumer.start();
       await clock.nextAsync();
-      consumer.stop({ waitForInFlightMessagesMs: 500 });
+      consumer.stop();
 
       await clock.runAllAsync();
 

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -1481,6 +1481,77 @@ describe('Consumer', () => {
       sandbox.assert.calledOnce(handleAbort);
       sandbox.assert.calledOnce(handleStop);
     });
+
+    it('waits for in-flight messages before emitting stopped (no timeout)', async () => {
+      const handleStop = sandbox.stub().returns(null);
+      const handleResponseProcessed = sandbox.stub().returns(null);
+
+      // A slow message handler
+      handleMessage = sandbox.stub().callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+      });
+
+      consumer = new Consumer({
+        queueUrl: QUEUE_URL,
+        region: REGION,
+        handleMessage,
+        sqs,
+        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT
+      });
+
+      consumer.on('stopped', handleStop);
+      consumer.on('response_processed', handleResponseProcessed);
+
+      consumer.start();
+      await clock.nextAsync();
+      consumer.stop({ waitForInFlightMessages: true });
+
+      await clock.runAllAsync();
+
+      sandbox.assert.calledOnce(handleStop);
+      sandbox.assert.calledOnce(handleResponseProcessed);
+      sandbox.assert.calledOnce(handleMessage);
+      assert.ok(handleMessage.calledBefore(handleStop));
+
+      // handleResponseProcessed is called after handleMessage, indicating
+      // messages were allowed to complete before 'stopped' was emitted
+      assert.ok(handleResponseProcessed.calledBefore(handleStop));
+    });
+
+    it('waits for in-flight messages before emitting stopped (timeout reached)', async () => {
+      const handleStop = sandbox.stub().returns(null);
+      const handleResponseProcessed = sandbox.stub().returns(null);
+
+      // A slow message handler
+      handleMessage = sandbox.stub().callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+      });
+
+      consumer = new Consumer({
+        queueUrl: QUEUE_URL,
+        region: REGION,
+        handleMessage,
+        sqs,
+        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT
+      });
+
+      consumer.on('stopped', handleStop);
+      consumer.on('response_processed', handleResponseProcessed);
+
+      consumer.start();
+      await clock.nextAsync();
+      consumer.stop({ waitForInFlightMessages: true, waitTimeoutMs: 500 });
+
+      await clock.runAllAsync();
+
+      sandbox.assert.calledOnce(handleStop);
+      sandbox.assert.calledOnce(handleResponseProcessed);
+      sandbox.assert.calledOnce(handleMessage);
+      assert(handleMessage.calledBefore(handleStop));
+
+      // Stop was called before the message could be processed, because we reached timeout.
+      assert(handleStop.calledBefore(handleResponseProcessed));
+    });
   });
 
   describe('isRunning', async () => {


### PR DESCRIPTION
Resolves https://github.com/bbc/sqs-consumer/discussions/410

**Description:**

Optionally delay the `emit('stopped')` event until in-flight messages
from the most recent poll have been processed.

Thank you for creating and maintaining a great module. `sqs-consumer` has been
pleasant tool to work with.

I'm entirely open to other suggestions of how to address the problem.  Maybe I'm missing something that already exists to accomplish this. Thanks in advance.

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

We are implementing a graceful shutdown of queue consumers just before issuing a process.exit() in our app

I'd like to support waiting for in-flight messages to be finalized before exiting, but it seems
the current implementation emits `stopped` without that guarantee.

**Code changes:**

- Add optional `pollingCompleteWaitTimeMs` option for `Consumer.create()` to enable the waiting behavior on shutdown.
- Add method `Consumer.waitForPollingToComplete()` that loops with 1s delay until all messages are processed, when feature is enabled.  The current `Consumer.stop()` method would use this to facilitate the waiting prior to emitting `stopped`

---

**Checklist:**

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
