### PR TITLE
feat!: replacing the isRunning method with status

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,15 @@ By default, the value of `abort` is set to `false` which means pre existing requ
 
 `consumer.stop({ abort: true })`
 
-### `consumer.isRunning`
+### `consumer.status`
 
-Returns the current polling state of the consumer: `true` if it is actively polling, `false` if it is not.
+Returns the current status of the consumer.
+
+- `isRunning` - `true` if the consumer has been started and not stopped, `false` if was not started or if it was stopped.
+- `isPolling` - `true` if the consumer is actively polling, `false` if it is not.
+
+> **Note:**
+> This method is not available in versions before v9.0.0 and replaced the method `isRunning` to supply both running and polling states.
 
 ### `consumer.updateOption(option, value)`
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lcov": "c8 mocha && c8 report --reporter=lcov",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --fix",
-    "format": "prettier --loglevel warn --write \"**/*.{js,json,jsx,md,ts,tsx,html}\"",
+    "format": "prettier --log-level warn --write \"**/*.{js,json,jsx,md,ts,tsx,html}\"",
     "format:check": "prettier --check \"**/*.{js,json,jsx,md,ts,tsx,html}\"",
     "posttest": "npm run lint && npm run format:check",
     "generate-docs": "typedoc"

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -56,7 +56,7 @@ export class Consumer extends TypedEventEmitter {
   private pollingWaitTimeMs: number;
   private pollingCompleteWaitTimeMs: number;
   private heartbeatInterval: number;
-  private isPolling: boolean;
+  private isPolling = false;
   private stopRequestedAtTimestamp: number;
   public abortController: AbortController;
 
@@ -174,10 +174,17 @@ export class Consumer extends TypedEventEmitter {
   }
 
   /**
-   * Returns the current polling state of the consumer: `true` if it is actively polling, `false` if it is not.
+   * Returns the current status of the consumer.
+   * This includes whether it is running or currently polling.
    */
-  public get isRunning(): boolean {
-    return !this.stopped;
+  public get status(): {
+    isRunning: boolean;
+    isPolling: boolean;
+  } {
+    return {
+      isRunning: !this.stopped,
+      isPolling: this.isPolling
+    };
   }
 
   /**
@@ -297,19 +304,11 @@ export class Consumer extends TypedEventEmitter {
     response: ReceiveMessageCommandOutput
   ): Promise<void> {
     if (hasMessages(response)) {
-      const handlerProcessingDebugger = setInterval(() => {
-        logger.debug('handler_processing', {
-          detail: 'The handler is still processing the message(s)...'
-        });
-      }, 1000);
-
       if (this.handleMessageBatch) {
         await this.processMessageBatch(response.Messages);
       } else {
         await Promise.all(response.Messages.map(this.processMessage));
       }
-
-      clearInterval(handlerProcessingDebugger);
 
       this.emit('response_processed');
     } else if (response) {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -304,11 +304,19 @@ export class Consumer extends TypedEventEmitter {
     response: ReceiveMessageCommandOutput
   ): Promise<void> {
     if (hasMessages(response)) {
+      const handlerProcessingDebugger = setInterval(() => {
+        logger.debug('handler_processing', {
+          detail: 'The handler is still processing the message(s)...'
+        });
+      }, 1000);
+
       if (this.handleMessageBatch) {
         await this.processMessageBatch(response.Messages);
       } else {
         await Promise.all(response.Messages.map(this.processMessage));
       }
+
+      clearInterval(handlerProcessingDebugger);
 
       this.emit('response_processed');
     } else if (response) {

--- a/test/features/step_definitions/gracefulShutdown.js
+++ b/test/features/step_definitions/gracefulShutdown.js
@@ -31,7 +31,7 @@ Then('the application is stopped while messages are in flight', async () => {
 
   consumer.stop();
 
-  assert.strictEqual(consumer.isRunning, false);
+  assert.strictEqual(consumer.status.isRunning, false);
 });
 
 Then(

--- a/test/features/step_definitions/handleMessage.js
+++ b/test/features/step_definitions/handleMessage.js
@@ -26,14 +26,12 @@ Given('a message is sent to the SQS queue', async () => {
 Then('the message should be consumed without error', async () => {
   consumer.start();
 
-  const isRunning = consumer.isRunning;
-
-  assert.strictEqual(isRunning, true);
+  assert.strictEqual(consumer.status.isRunning, true);
 
   await pEvent(consumer, 'response_processed');
 
   consumer.stop();
-  assert.strictEqual(consumer.isRunning, false);
+  assert.strictEqual(consumer.status.isRunning, false);
 
   const size = await producer.queueSize();
   assert.strictEqual(size, 0);
@@ -61,7 +59,7 @@ Then(
   async () => {
     consumer.start();
 
-    assert.strictEqual(consumer.isRunning, true);
+    assert.strictEqual(consumer.status.isRunning, true);
 
     await pEvent(consumer, 'message_received');
     const size = await producer.queueSize();
@@ -82,7 +80,7 @@ Then(
 
     consumer.stop();
 
-    assert.strictEqual(consumer.isRunning, false);
+    assert.strictEqual(consumer.status.isRunning, false);
   }
 );
 

--- a/test/features/step_definitions/handleMessageBatch.js
+++ b/test/features/step_definitions/handleMessageBatch.js
@@ -26,14 +26,12 @@ Given('a message batch is sent to the SQS queue', async () => {
 Then('the message batch should be consumed without error', async () => {
   consumer.start();
 
-  const isRunning = consumer.isRunning;
-
-  assert.strictEqual(isRunning, true);
+  assert.strictEqual(consumer.status.isRunning, true);
 
   await pEvent(consumer, 'response_processed');
 
   consumer.stop();
-  assert.strictEqual(consumer.isRunning, false);
+  assert.strictEqual(consumer.status.isRunning, false);
 
   const size = await producer.queueSize();
   assert.strictEqual(size, 0);
@@ -61,9 +59,7 @@ Then(
   async () => {
     consumer.start();
 
-    const isRunning = consumer.isRunning;
-
-    assert.strictEqual(isRunning, true);
+    assert.strictEqual(consumer.status.isRunning, true);
 
     await pEvent(consumer, 'message_received');
 
@@ -76,7 +72,7 @@ Then(
     assert.strictEqual(size2, 0);
 
     consumer.stop();
-    assert.strictEqual(consumer.isRunning, false);
+    assert.strictEqual(consumer.status.isRunning, false);
   }
 );
 

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -1768,32 +1768,33 @@ describe('Consumer', () => {
       sandbox.assert.calledWithMatch(loggerDebug, 'stopping');
       sandbox.assert.calledWithMatch(loggerDebug, 'stopped');
     });
-  });
 
-  it('logs a debug event while the handler is processing, for every second', async () => {
-    const loggerDebug = sandbox.stub(logger, 'debug');
-    const clearIntervalSpy = sinon.spy(global, 'clearInterval');
+    it('logs a debug event while the handler is processing, for every second', async () => {
+      const loggerDebug = sandbox.stub(logger, 'debug');
+      const clearIntervalSpy = sinon.spy(global, 'clearInterval');
 
-    sqs.send.withArgs(mockReceiveMessage).resolves({
-      Messages: [
-        { MessageId: '1', ReceiptHandle: 'receipt-handle-1', Body: 'body-1' }
-      ]
-    });
-    consumer = new Consumer({
-      queueUrl: QUEUE_URL,
-      region: REGION,
-      handleMessage: () => new Promise((resolve) => setTimeout(resolve, 4000)),
-      sqs
-    });
+      sqs.send.withArgs(mockReceiveMessage).resolves({
+        Messages: [
+          { MessageId: '1', ReceiptHandle: 'receipt-handle-1', Body: 'body-1' }
+        ]
+      });
+      consumer = new Consumer({
+        queueUrl: QUEUE_URL,
+        region: REGION,
+        handleMessage: () =>
+          new Promise((resolve) => setTimeout(resolve, 4000)),
+        sqs
+      });
 
-    consumer.start();
-    await Promise.all([clock.tickAsync(5000)]);
-    sandbox.assert.calledOnce(clearIntervalSpy);
-    consumer.stop();
+      consumer.start();
+      await Promise.all([clock.tickAsync(5000)]);
+      sandbox.assert.calledOnce(clearIntervalSpy);
+      consumer.stop();
 
-    sandbox.assert.callCount(loggerDebug, 15);
-    sandbox.assert.calledWith(loggerDebug, 'handler_processing', {
-      detail: 'The handler is still processing the message(s)...'
+      sandbox.assert.callCount(loggerDebug, 15);
+      sandbox.assert.calledWith(loggerDebug, 'handler_processing', {
+        detail: 'The handler is still processing the message(s)...'
+      });
     });
   });
 });


### PR DESCRIPTION
**Description:**
Following on from #454, this removes the `isRunning` method in favour of a `status` method that returns both the running and polling state.

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
This would allow users to get the running and polling state from one method rather than creating multiple ways of getting this information, it can also be expanded in the future with more information.

This is a breaking change as it changes an existing method, outside of that, this change should not actually effect how the Consumer processes messages.

**Code changes:**

- Updated the README to document the old state and the removal of `isRunning`
- Added a new `getStatus` method to return the states
- Updated tests
