### PR TITLE
feat!: removing handler_processing debugger in favour of status

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -164,12 +164,12 @@ export class Consumer extends TypedEventEmitter {
       Date.now() - this.stopRequestedAtTimestamp >
       this.pollingCompleteWaitTimeMs;
     if (exceededTimeout) {
-      logger.debug('waiting_for_polling_to_complete_timeout_exceeded');
+      this.emit('waiting_for_polling_to_complete_timeout_exceeded');
       this.emit('stopped');
       return;
     }
 
-    logger.debug('waiting_for_polling_to_complete');
+    this.emit('waiting_for_polling_to_complete');
     setTimeout(this.waitForPollingToComplete, 1000);
   }
 
@@ -304,19 +304,11 @@ export class Consumer extends TypedEventEmitter {
     response: ReceiveMessageCommandOutput
   ): Promise<void> {
     if (hasMessages(response)) {
-      const handlerProcessingDebugger = setInterval(() => {
-        logger.debug('handler_processing', {
-          detail: 'The handler is still processing the message(s)...'
-        });
-      }, 1000);
-
       if (this.handleMessageBatch) {
         await this.processMessageBatch(response.Messages);
       } else {
         await Promise.all(response.Messages.map(this.processMessage));
       }
-
-      clearInterval(handlerProcessingDebugger);
 
       this.emit('response_processed');
     } else if (response) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,6 +197,14 @@ export interface Events {
    * Fired when an option is updated
    */
   option_updated: [UpdatableOptions, ConsumerOptions[UpdatableOptions]];
+  /**
+   * Fired when the Consumer is waiting for polling to complete before stopping.
+   */
+  waiting_for_polling_to_complete: [];
+  /**
+   * Fired when the Consumer has waited for polling to complete and is stopping due to a timeout.
+   */
+  waiting_for_polling_to_complete_timeout_exceeded: [];
 }
 
 export type AWSError = {


### PR DESCRIPTION
Resolves #469

**Description:**

The PR removes the debugger that was previously added that would send a `handler_processing` debug log every second while polling was ongoing.

This is no longer required as the new status method returns this information.

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

This simplifies the codebase and makes it easier for us to maintain, and to understand.

**Code changes:**

- Removes the `handler_processing` debugger
- Changes `waiting_for_polling_to_complete` and `waiting_for_polling_to_complete_timeout_exceeded` to emit so users can react to them easier
- Fixes some flaky test issues

---

