### PR TITLE
chore: adding a link to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ npm install sqs-consumer
 
 We will only support Node versions that are actively or security supported by the Node team. If you are still using an Node 14, please use a version of this library before the v7 release, if you are using Node 16, please use a version before the v7.3.0 release.
 
+## Documentation
+
+Visit [https://bbc.github.io/sqs-consumer/](https://bbc.github.io/sqs-consumer/) for the full API documentation.
+
 ## Usage
 
 ```js


### PR DESCRIPTION
Resolves #464

Just adds a link to the readme to direct users to the documentation as we've had feedback that it wasn't easily found.