### PR TITLE
feat: Add useQueueUrlAsEndpoint to ConsumerOptions

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -86,6 +86,7 @@ export class Consumer extends TypedEventEmitter {
     this.sqs =
       options.sqs ||
       new SQSClient({
+        useQueueUrlAsEndpoint: options.useQueueUrlAsEndpoint ?? true,
         region: options.region || process.env.AWS_REGION || 'eu-west-1'
       });
     autoBind(this);

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,11 @@ export interface ConsumerOptions {
    */
   region?: string;
   /**
+   * If false uses the QueueUrl hostname as the endpoint.
+   * @defaultValue `true`
+   */
+  useQueueUrlAsEndpoint?: boolean;
+  /**
    * Time in ms to wait for `handleMessage` to process a message before timing out.
    *
    * Emits `timeout_error` on timeout. By default, if `handleMessage` times out,


### PR DESCRIPTION
Resolves #NUMBER

**Description:**

Add useQueueUrlAsEndpoint support in Consumer initialization

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

Let use QueueUrl hostname as the endpoint with [@aws-sdk/client-sqs@^v3.507.0](https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.507.0)

**Code changes:**

Add useQueueUrlAsEndpoint to ComsumerOptions, so it can be passed to SQSClient.
Add useQueueUrlAsEndpoint check in Consumer constructor to pass true as default value.

---

**Checklist:**

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
