### PR TITLE
fix: handle CredentialsProviderError from AWS SDK JS v3

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -46,7 +46,8 @@ function isConnectionError(err: Error): boolean {
       err.statusCode === 403 ||
       err.code === 'CredentialsError' ||
       err.code === 'UnknownEndpoint' ||
-      err.code === 'AWS.SimpleQueueService.NonExistentQueue'
+      err.code === 'AWS.SimpleQueueService.NonExistentQueue' ||
+      err.code === 'CredentialsProviderError'
     );
   }
   return false;


### PR DESCRIPTION
Resolves #473

**Description:**

AWS surfaces a `CredentialsProviderError` when credentials could not be loaded from any providers, SQS Consumer doesn't currently handle this.

**Type of change:**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
Handle error thrown by AWS SDK for JavaScript v3 which should be treated as an authentication failure.

**Code changes:**

- The `isConnectionError` function will return `true` when passed a `CredentialsProviderError`

---

**Checklist:**

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
