### PR TITLE
fix: Added connection error timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-consumer",
-  "version": "10.1.0-canary.1",
+  "version": "10.0.0-canary.3",
   "description": "Build SQS-based Node applications without the boilerplate",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-consumer",
-  "version": "10.0.0-canary.3",
+  "version": "10.1.0-canary.1",
   "description": "Build SQS-based Node applications without the boilerplate",
   "type": "module",
   "exports": {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -52,6 +52,7 @@ export class Consumer extends TypedEventEmitter {
   private terminateVisibilityTimeout: boolean;
   private waitTimeSeconds: number;
   private authenticationErrorTimeout: number;
+  private connectionErrorTimeout: number;
   private pollingWaitTimeMs: number;
   private pollingCompleteWaitTimeMs: number;
   private heartbeatInterval: number;
@@ -78,6 +79,7 @@ export class Consumer extends TypedEventEmitter {
     this.waitTimeSeconds = options.waitTimeSeconds ?? 20;
     this.authenticationErrorTimeout =
       options.authenticationErrorTimeout ?? 10000;
+    this.connectionErrorTimeout = options.connectionErrorTimeout ?? 10000;
     this.pollingWaitTimeMs = options.pollingWaitTimeMs ?? 0;
     this.pollingCompleteWaitTimeMs = options.pollingCompleteWaitTimeMs ?? 0;
     this.shouldDeleteMessages = options.shouldDeleteMessages ?? true;
@@ -255,6 +257,12 @@ export class Consumer extends TypedEventEmitter {
               "There was an authentication error. Pausing before retrying.",
           });
           currentPollingTimeout = this.authenticationErrorTimeout;
+        } else {
+          logger.debug("connection_error", {
+            detail:
+              "There was a connection error. Pausing before retrying.",
+          });
+          currentPollingTimeout = this.connectionErrorTimeout;
         }
         return;
       })

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -49,6 +49,7 @@ function isConnectionError(err: Error): boolean {
       err.code === "UnknownEndpoint" ||
       err.code === "AWS.SimpleQueueService.NonExistentQueue" ||
       err.code === "CredentialsProviderError" ||
+      err.code === "QueueDoesNotExist" ||
       err.code === "InvalidAddress"
     );
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -44,10 +44,12 @@ function isConnectionError(err: Error): boolean {
   if (err instanceof SQSError) {
     return (
       err.statusCode === 403 ||
+      err.name === "SQSError" ||
       err.code === "CredentialsError" ||
       err.code === "UnknownEndpoint" ||
       err.code === "AWS.SimpleQueueService.NonExistentQueue" ||
-      err.code === "CredentialsProviderError"
+      err.code === "CredentialsProviderError" ||
+      err.code === "InvalidAddress"
     );
   }
   return false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,12 +40,7 @@ export interface ConsumerOptions {
    */
   waitTimeSeconds?: number;
   /**
-   * The duration (in milliseconds) to wait before retrying after an authentication error.
-   * @defaultvalue `10000`
-   */
-  authenticationErrorTimeout?: number;
-  /**
-   * The duration (in milliseconds) to wait before retrying after a connection error.
+   * The duration (in milliseconds) to wait before retrying after a connection or authentication error.
    * @defaultvalue `10000`
    */
   connectionErrorTimeout?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,11 @@ export interface ConsumerOptions {
    */
   authenticationErrorTimeout?: number;
   /**
+   * The duration (in milliseconds) to wait before retrying after a connection error.
+   * @defaultvalue `10000`
+   */
+  connectionErrorTimeout?: number;
+  /**
    * The duration (in milliseconds) to wait before repolling the queue.
    * @defaultvalue `0`
    */

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -17,7 +17,6 @@ import { logger } from "../../src/logger.js";
 
 const sandbox = sinon.createSandbox();
 
-const AUTHENTICATION_ERROR_TIMEOUT = 20;
 const CONNECTION_ERROR_TIMEOUT = 20;
 const POLLING_TIMEOUT = 100;
 const QUEUE_URL = "some-queue-url";
@@ -87,7 +86,6 @@ describe("Consumer", () => {
       region: REGION,
       handleMessage,
       sqs,
-      authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
       connectionErrorTimeout: CONNECTION_ERROR_TIMEOUT,
     });
   });
@@ -258,7 +256,7 @@ describe("Consumer", () => {
           new Promise((resolve) => setTimeout(resolve, 1000)),
         handleMessageTimeout,
         sqs,
-        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
+        connectionErrorTimeout: CONNECTION_ERROR_TIMEOUT,
       });
 
       consumer.start();
@@ -283,7 +281,7 @@ describe("Consumer", () => {
           throw new Error("unexpected parsing error");
         },
         sqs,
-        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
+        connectionErrorTimeout: CONNECTION_ERROR_TIMEOUT,
       });
 
       consumer.start();
@@ -317,7 +315,7 @@ describe("Consumer", () => {
           throw new CustomError("unexpected parsing error");
         },
         sqs,
-        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
+        connectionErrorTimeout: CONNECTION_ERROR_TIMEOUT,
       });
 
       consumer.start();
@@ -341,7 +339,7 @@ describe("Consumer", () => {
           throw customError;
         },
         sqs,
-        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
+        connectionErrorTimeout: CONNECTION_ERROR_TIMEOUT,
       });
 
       consumer.start();
@@ -420,7 +418,7 @@ describe("Consumer", () => {
       consumer.on("error", errorListener);
 
       consumer.start();
-      await clock.tickAsync(AUTHENTICATION_ERROR_TIMEOUT);
+      await clock.tickAsync(CONNECTION_ERROR_TIMEOUT);
       consumer.stop();
 
       sandbox.assert.calledTwice(errorListener);
@@ -440,7 +438,7 @@ describe("Consumer", () => {
       consumer.on("error", errorListener);
 
       consumer.start();
-      await clock.tickAsync(AUTHENTICATION_ERROR_TIMEOUT);
+      await clock.tickAsync(CONNECTION_ERROR_TIMEOUT);
       consumer.stop();
 
       sandbox.assert.calledTwice(errorListener);
@@ -459,7 +457,7 @@ describe("Consumer", () => {
       consumer.on("error", errorListener);
 
       consumer.start();
-      await clock.tickAsync(AUTHENTICATION_ERROR_TIMEOUT);
+      await clock.tickAsync(CONNECTION_ERROR_TIMEOUT);
       consumer.stop();
 
       sandbox.assert.calledTwice(errorListener);
@@ -471,6 +469,7 @@ describe("Consumer", () => {
     it("waits before repolling when a connection error occurs", async () => {
       const unknownEndpointErr = {
         name: "SQSError",
+        code: "SQSError",
         message:
           "SQS receive message failed: getaddrinfo ENOTFOUND sqs.eu-west-1.amazonaws.com",
       };
@@ -498,7 +497,7 @@ describe("Consumer", () => {
       consumer.on("error", errorListener);
 
       consumer.start();
-      await clock.tickAsync(AUTHENTICATION_ERROR_TIMEOUT);
+      await clock.tickAsync(CONNECTION_ERROR_TIMEOUT);
       consumer.stop();
 
       sandbox.assert.calledTwice(errorListener);
@@ -517,7 +516,7 @@ describe("Consumer", () => {
       consumer.on("error", errorListener);
 
       consumer.start();
-      await clock.tickAsync(AUTHENTICATION_ERROR_TIMEOUT);
+      await clock.tickAsync(CONNECTION_ERROR_TIMEOUT);
       consumer.stop();
 
       sandbox.assert.calledTwice(errorListener);
@@ -532,7 +531,7 @@ describe("Consumer", () => {
         region: REGION,
         handleMessage,
         sqs,
-        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
+        connectionErrorTimeout: CONNECTION_ERROR_TIMEOUT,
         pollingWaitTimeMs: POLLING_TIMEOUT,
       });
 
@@ -582,7 +581,7 @@ describe("Consumer", () => {
         region: REGION,
         handleMessage,
         sqs,
-        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
+        connectionErrorTimeout: CONNECTION_ERROR_TIMEOUT,
         preReceiveMessageCallback: preReceiveMessageCallbackStub,
         postReceiveMessageCallback: postReceiveMessageCallbackStub,
       });
@@ -618,7 +617,7 @@ describe("Consumer", () => {
         region: REGION,
         handleMessage,
         sqs,
-        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
+        connectionErrorTimeout: CONNECTION_ERROR_TIMEOUT,
         shouldDeleteMessages: false,
       });
 
@@ -723,7 +722,7 @@ describe("Consumer", () => {
           AttributeNames: [],
           MessageAttributeNames: ["attribute-1", "attribute-2"],
           MaxNumberOfMessages: 3,
-          WaitTimeSeconds: AUTHENTICATION_ERROR_TIMEOUT,
+          WaitTimeSeconds: CONNECTION_ERROR_TIMEOUT,
           VisibilityTimeout: undefined,
         }),
       );
@@ -767,7 +766,7 @@ describe("Consumer", () => {
           AttributeNames: ["ApproximateReceiveCount"],
           MessageAttributeNames: [],
           MaxNumberOfMessages: 1,
-          WaitTimeSeconds: AUTHENTICATION_ERROR_TIMEOUT,
+          WaitTimeSeconds: CONNECTION_ERROR_TIMEOUT,
           VisibilityTimeout: undefined,
         }),
       );
@@ -903,7 +902,7 @@ describe("Consumer", () => {
         },
         batchSize: 2,
         sqs,
-        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
+        connectionErrorTimeout: CONNECTION_ERROR_TIMEOUT,
       });
 
       consumer.start();
@@ -939,7 +938,7 @@ describe("Consumer", () => {
         },
         batchSize: 2,
         sqs,
-        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
+        connectionErrorTimeout: CONNECTION_ERROR_TIMEOUT,
       });
 
       consumer.start();
@@ -965,7 +964,7 @@ describe("Consumer", () => {
         },
         batchSize: 2,
         sqs,
-        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
+        connectionErrorTimeout: CONNECTION_ERROR_TIMEOUT,
       });
 
       consumer.start();
@@ -1547,7 +1546,7 @@ describe("Consumer", () => {
         handleMessage,
         sqs,
         pollingCompleteWaitTimeMs: 5000,
-        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
+        connectionErrorTimeout: CONNECTION_ERROR_TIMEOUT,
       });
 
       consumer.on("stopped", handleStop);
@@ -1601,7 +1600,7 @@ describe("Consumer", () => {
         handleMessage,
         sqs,
         pollingCompleteWaitTimeMs: 500,
-        authenticationErrorTimeout: AUTHENTICATION_ERROR_TIMEOUT,
+        connectionErrorTimeout: CONNECTION_ERROR_TIMEOUT,
       });
 
       consumer.on("stopped", handleStop);


### PR DESCRIPTION
Resolves #484

**Description:**
Adds a timeout when a connection to SQS fails due to a lack of internet connection, invalid queue name etc.

**Type of change:**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
Currently when a connection fails it will be immediately retried causing an instant loop of retries with lots of unnecessary requests and error events.

**Code changes:**

This pull request primarily involves renaming "authentication errors" in the codebase, changing them to "connection errors". and adding the additional failure error events. This includes changes in variable names, method parameters, and error handling logic. The changes are spread across the `src/consumer.ts`, `src/types.ts`, `src/errors.ts`, and `test/tests/consumer.test.ts` files.

Here are the most important changes:

Renaming and refactoring:

* [`src/consumer.ts`](diffhunk://#diff-720b6bfe5e0c4c43dcef59d90017b3517a0cfaa675b8f017ecf9e29fabfa48efL54-R54): Renamed the `authenticationErrorTimeout` variable to `connectionErrorTimeout` in the `Consumer` class and updated the corresponding assignment and usage in error handling. [[1]](diffhunk://#diff-720b6bfe5e0c4c43dcef59d90017b3517a0cfaa675b8f017ecf9e29fabfa48efL54-R54) [[2]](diffhunk://#diff-720b6bfe5e0c4c43dcef59d90017b3517a0cfaa675b8f017ecf9e29fabfa48efL79-R80) [[3]](diffhunk://#diff-720b6bfe5e0c4c43dcef59d90017b3517a0cfaa675b8f017ecf9e29fabfa48efR252-L259)
* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL43-R46): Updated the `ConsumerOptions` interface to rename `authenticationErrorTimeout` to `connectionErrorTimeout`.
* [`src/errors.ts`](diffhunk://#diff-55db69e02ff5714d444d8081ec6ecac5d9833fb29fda64d1e829e5766434fdc0R47-R52): Updated the `isConnectionError` function to include more error codes that are considered as connection errors.
* [`test/tests/consumer.test.ts`](diffhunk://#diff-536e9856553af255bee7ebb5feb7e07efeb21d0e1e24485fb2533a71c30ad004L20-R20): Updated the test cases to use `CONNECTION_ERROR_TIMEOUT` instead of `AUTHENTICATION_ERROR_TIMEOUT`. Also, added a test case to handle connection errors. [[1]](diffhunk://#diff-536e9856553af255bee7ebb5feb7e07efeb21d0e1e24485fb2533a71c30ad004L20-R20) [[2]](diffhunk://#diff-536e9856553af255bee7ebb5feb7e07efeb21d0e1e24485fb2533a71c30ad004L89-R89) [[3]](diffhunk://#diff-536e9856553af255bee7ebb5feb7e07efeb21d0e1e24485fb2533a71c30ad004L460-R481)

These changes appear to broaden the scope of errors considered as connection issues and handle them uniformly across the application.

---

**Checklist:**

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
