### PR TITLE
feat: extend authentication error to handle more codes

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -251,6 +251,7 @@ export class Consumer extends TypedEventEmitter {
         this.emitError(err);
         if (isConnectionError(err)) {
           logger.debug("authentication_error", {
+            code: err.code || "Unknown",
             detail:
               "There was an authentication error. Pausing before retrying.",
           });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -37,23 +37,27 @@ class StandardError extends Error {
 }
 
 /**
+ * List of SQS error codes that are considered connection errors.
+ */
+const CONNECTION_ERRORS = [
+  "CredentialsError",
+  "UnknownEndpoint",
+  "AWS.SimpleQueueService.NonExistentQueue",
+  "CredentialsProviderError",
+  "InvalidAddress",
+  "InvalidSecurity",
+  "QueueDoesNotExist",
+  "RequestThrottled",
+  "OverLimit",
+];
+
+/**
  * Checks if the error provided should be treated as a connection error.
  * @param err The error that was received.
  */
 function isConnectionError(err: Error): boolean {
   if (err instanceof SQSError) {
-    return (
-      err.statusCode === 403 ||
-      err.code === "CredentialsError" ||
-      err.code === "UnknownEndpoint" ||
-      err.code === "AWS.SimpleQueueService.NonExistentQueue" ||
-      err.code === "CredentialsProviderError" ||
-      err.code === "InvalidAddress" ||
-      err.code === "InvalidSecurity" ||
-      err.code === "QueueDoesNotExist" ||
-      err.code === "RequestThrottled" ||
-      err.code === "OverLimit"
-    );
+    return err.statusCode === 403 || CONNECTION_ERRORS.includes(err.code);
   }
   return false;
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -47,7 +47,12 @@ function isConnectionError(err: Error): boolean {
       err.code === "CredentialsError" ||
       err.code === "UnknownEndpoint" ||
       err.code === "AWS.SimpleQueueService.NonExistentQueue" ||
-      err.code === "CredentialsProviderError"
+      err.code === "CredentialsProviderError" ||
+      err.code === "InvalidAddress" ||
+      err.code === "InvalidSecurity" ||
+      err.code === "QueueDoesNotExist" ||
+      err.code === "RequestThrottled" ||
+      err.code === "OverLimit"
     );
   }
   return false;


### PR DESCRIPTION
Resolves #484

**Description:**

SQS Consumer does not currently handle some other connection / authentication errors that SQS sends out. This PR extends the code to handle these as connection errors, which will cause the polling timeout to be extended.

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

This allows users to better respond to these issues and stops the consumer from pinging SQS too often as these errors are expected to persist for some time.

**Code changes:**

- Extended isConnectionError to handle `InvalidAddress` | `InvalidSecurity` | `QueueDoesNotExist` | `RequestThrottled` | `OverLimit`
- Added the code to the debug logger so that the user can see why an authentication error occurred.

