### PR TITLE
chore: adding main and types back

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "10.1.0",
   "description": "Build SQS-based Node applications without the boilerplate",
   "type": "module",
+  "main": "dist/cjs/index.js",
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
This adds the `main` and `types` fields back to hopefully support node versions 10 or older, this will be released as a canary for investigation.