### PR TITLE
chore: upgrading aws sdk to ^3.614.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sqs": "^3.609.0",
+        "@aws-sdk/client-sqs": "^3.614.0",
         "debug": "^4.3.5"
       },
       "devDependencies": {
@@ -48,7 +48,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sqs": "^3.609.0"
+        "@aws-sdk/client-sqs": "^3.614.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -195,49 +195,49 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.609.0.tgz",
-      "integrity": "sha512-0cJsOWp1AOt7MYNdpq8k0nDY5g2twXdnTcryljubIXJJMrORSd4p9YtH3X8auJaqb9vd2t/D8XhoJTNbTC/4lQ==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.614.0.tgz",
+      "integrity": "sha512-jCeHIlfwBSuoKN7Nf+DHYbH1eBuWALf+o9WaK8J+xhU0VE6G0DGdjHhjW1aTGTchBntARzqzMqwvY1e18Ac1zQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/client-sts": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.614.0",
+        "@aws-sdk/client-sts": "3.614.0",
+        "@aws-sdk/core": "3.614.0",
+        "@aws-sdk/credential-provider-node": "3.614.0",
         "@aws-sdk/middleware-host-header": "3.609.0",
         "@aws-sdk/middleware-logger": "3.609.0",
         "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-sdk-sqs": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.614.0",
+        "@aws-sdk/middleware-user-agent": "3.614.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.6",
+        "@smithy/fetch-http-handler": "^3.2.1",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
         "@smithy/md5-js": "^3.0.3",
         "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.9",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.2",
         "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/smithy-client": "^3.1.7",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.9",
+        "@smithy/util-defaults-mode-node": "^3.0.9",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -252,44 +252,44 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.609.0.tgz",
-      "integrity": "sha512-gqXGFDkIpKHCKAbeJK4aIDt3tiwJ26Rf5Tqw9JS6BYXsdMeOB8FTzqD9R+Yc1epHd8s5L94sdqXT5PapgxFZrg==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.614.0.tgz",
+      "integrity": "sha512-p5pyYaxRzBttjBkqfc8i3K7DzBdTg3ECdVgBo6INIUxfvDy0J8QUE8vNtCgvFIkq+uPw/8M+Eo4zzln7anuO0Q==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.609.0",
+        "@aws-sdk/core": "3.614.0",
         "@aws-sdk/middleware-host-header": "3.609.0",
         "@aws-sdk/middleware-logger": "3.609.0",
         "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-user-agent": "3.614.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.6",
+        "@smithy/fetch-http-handler": "^3.2.1",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
         "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.9",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.2",
         "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/smithy-client": "^3.1.7",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.9",
+        "@smithy/util-defaults-mode-node": "^3.0.9",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -300,45 +300,45 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.609.0.tgz",
-      "integrity": "sha512-0bNPAyPdkWkS9EGB2A9BZDkBNrnVCBzk5lYRezoT4K3/gi9w1DTYH5tuRdwaTZdxW19U1mq7CV0YJJARKO1L9Q==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.614.0.tgz",
+      "integrity": "sha512-BI1NWcpppbHg/28zbUg54dZeckork8BItZIcjls12vxasy+p3iEzrJVG60jcbUTTsk3Qc1tyxNfrdcVqx0y7Ww==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
+        "@aws-sdk/core": "3.614.0",
+        "@aws-sdk/credential-provider-node": "3.614.0",
         "@aws-sdk/middleware-host-header": "3.609.0",
         "@aws-sdk/middleware-logger": "3.609.0",
         "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-user-agent": "3.614.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.6",
+        "@smithy/fetch-http-handler": "^3.2.1",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
         "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.9",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.2",
         "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/smithy-client": "^3.1.7",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.9",
+        "@smithy/util-defaults-mode-node": "^3.0.9",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -348,7 +348,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.614.0"
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
@@ -362,46 +362,46 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.609.0.tgz",
-      "integrity": "sha512-A0B3sDKFoFlGo8RYRjDBWHXpbgirer2bZBkCIzhSPHc1vOFHt/m2NcUoE2xnBKXJFrptL1xDkvo1P+XYp/BfcQ==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.614.0.tgz",
+      "integrity": "sha512-i6QmaVA1KHHYNnI2VYQy/sc31rLm4+jSp8b/YbQpFnD0w3aXsrEEHHlxek45uSkHb4Nrj1omFBVy/xp1WVYx2Q==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.614.0",
+        "@aws-sdk/core": "3.614.0",
+        "@aws-sdk/credential-provider-node": "3.614.0",
         "@aws-sdk/middleware-host-header": "3.609.0",
         "@aws-sdk/middleware-logger": "3.609.0",
         "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-user-agent": "3.614.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.6",
+        "@smithy/fetch-http-handler": "^3.2.1",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
         "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.9",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.2",
         "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/smithy-client": "^3.1.7",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.9",
+        "@smithy/util-defaults-mode-node": "^3.0.9",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -417,14 +417,14 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.609.0.tgz",
-      "integrity": "sha512-ptqw+DTxLr01+pKjDUuo53SEDzI+7nFM3WfQaEo0yhDg8vWw8PER4sWj1Ysx67ksctnZesPUjqxd5SHbtdBxiA==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.614.0.tgz",
+      "integrity": "sha512-BUuS5/1YkgmKc4J0bg83XEtMyDHVyqG2QDzfmhYe8gbOIZabUl1FlrFVwhCAthtrrI6MPGTQcERB4BtJKUSplw==",
       "dependencies": {
-        "@smithy/core": "^2.2.4",
+        "@smithy/core": "^2.2.6",
         "@smithy/protocol-http": "^4.0.3",
         "@smithy/signature-v4": "^3.1.2",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/smithy-client": "^3.1.7",
         "@smithy/types": "^3.3.0",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.6.2"
@@ -458,18 +458,18 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.609.0.tgz",
-      "integrity": "sha512-GQQfB9Mk4XUZwaPsk4V3w8MqleS6ApkZKVQn3vTLAKa8Y7B2Imcpe5zWbKYjDd8MPpMWjHcBGFTVlDRFP4zwSQ==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.614.0.tgz",
+      "integrity": "sha512-YIEjlNUKb3Vo/iTnGAPdsiDC3FUUnNoex2OwU8LmR7AkYZiWdB8nx99DfgkkY+OFMUpw7nKD2PCOtuFONelfGA==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/node-http-handler": "^3.1.1",
+        "@smithy/fetch-http-handler": "^3.2.1",
+        "@smithy/node-http-handler": "^3.1.2",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/smithy-client": "^3.1.7",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.0.5",
+        "@smithy/util-stream": "^3.0.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -482,19 +482,19 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.609.0.tgz",
-      "integrity": "sha512-hwaBfXuBTv6/eAdEsDfGcteYUW6Km7lvvubbxEdxIuJNF3vswR7RMGIXaEC37hhPkTTgd3H0TONammhwZIfkog==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.614.0.tgz",
+      "integrity": "sha512-KfLuLFGwlvFSZ2MuzYwWGPb1y5TeiwX5okIDe0aQ1h10oD3924FXbN+mabOnUHQ8EFcGAtCaWbrC86mI7ktC6A==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
+        "@aws-sdk/credential-provider-http": "3.614.0",
+        "@aws-sdk/credential-provider-process": "3.614.0",
+        "@aws-sdk/credential-provider-sso": "3.614.0",
         "@aws-sdk/credential-provider-web-identity": "3.609.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
+        "@smithy/credential-provider-imds": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -502,7 +502,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.614.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
@@ -511,20 +511,20 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.609.0.tgz",
-      "integrity": "sha512-4J8/JRuqfxJDGD9jTHVCBxCvYt7/Vgj2Stlhj930mrjFPO/yRw8ilAAZxBWe0JHPX3QwepCmh4ErZe53F5ysxQ==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.614.0.tgz",
+      "integrity": "sha512-4J6gPEuFZP0mkWq5E//oMS1vrmMM88iNNcv7TEljYnsc6JTAlKejCyFwx6CN+nkIhmIZsl06SXIhBemzBdBPfg==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-ini": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
+        "@aws-sdk/credential-provider-http": "3.614.0",
+        "@aws-sdk/credential-provider-ini": "3.614.0",
+        "@aws-sdk/credential-provider-process": "3.614.0",
+        "@aws-sdk/credential-provider-sso": "3.614.0",
         "@aws-sdk/credential-provider-web-identity": "3.609.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
+        "@smithy/credential-provider-imds": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -538,13 +538,13 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.609.0.tgz",
-      "integrity": "sha512-Ux35nGOSJKZWUIM3Ny0ROZ8cqPRUEkh+tR3X2o9ydEbFiLq3eMMyEnHJqx4EeUjLRchidlm4CCid9GxMe5/gdw==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.614.0.tgz",
+      "integrity": "sha512-Q0SI0sTRwi8iNODLs5+bbv8vgz8Qy2QdxbCHnPk/6Cx6LMf7i3dqmWquFbspqFRd8QiqxStrblwxrUYZi09tkA==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -558,15 +558,15 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.609.0.tgz",
-      "integrity": "sha512-oQPGDKMMIxjvTcm86g07RPYeC7mCNk+29dPpY15ZAPRpAF7F0tircsC3wT9fHzNaKShEyK5LuI5Kg/uxsdy+Iw==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.614.0.tgz",
+      "integrity": "sha512-55+gp0JY4451cWI1qXmVMFM0GQaBKiQpXv2P0xmd9P3qLDyeFUSEW8XPh0d2lb1ICr6x4s47ynXVdGCIv2mXMg==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.609.0",
-        "@aws-sdk/token-providers": "3.609.0",
+        "@aws-sdk/client-sso": "3.614.0",
+        "@aws-sdk/token-providers": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -658,12 +658,12 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.609.0.tgz",
-      "integrity": "sha512-0rbOiErKuKIc9fLyjiqtjgAcUt6yBBcXVwta/q+W7WLxJbNtkTfGKfKhxPtp0+5S8EyljMpg2rITBCJzNRXjiA==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.614.0.tgz",
+      "integrity": "sha512-TFBbXEMnzBqGVPatL5Pg8a3kPOUrhSWxXXWZjr6S4D5ffCJnCNSzfi09SUoehe6uYmTQlS7AAqugTIFdRnA/ww==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/smithy-client": "^3.1.7",
         "@smithy/types": "^3.3.0",
         "@smithy/util-hex-encoding": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
@@ -679,12 +679,12 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.609.0.tgz",
-      "integrity": "sha512-nbq7MXRmeXm4IDqh+sJRAxGPAq0OfGmGIwKvJcw66hLoG8CmhhVMZmIAEBDFr57S+YajGwnLLRt+eMI05MMeVA==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.614.0.tgz",
+      "integrity": "sha512-xUxh0UPQiMTG6E31Yvu6zVYlikrIcFDKljM11CaatInzvZubGTGiX0DjpqRlfGzUNsuPc/zNrKwRP2+wypgqIw==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
         "@smithy/protocol-http": "^4.0.3",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -699,12 +699,12 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.609.0.tgz",
-      "integrity": "sha512-lMHBG8zg9GWYBc9/XVPKyuAUd7iKqfPP7z04zGta2kGNOKbUTeqmAdc1gJGku75p4kglIPlGBorOxti8DhRmKw==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "@smithy/util-config-provider": "^3.0.0",
         "@smithy/util-middleware": "^3.0.3",
@@ -720,13 +720,13 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.609.0.tgz",
-      "integrity": "sha512-WvhW/7XSf+H7YmtiIigQxfDVZVZI7mbKikQ09YpzN7FeN3TmYib1+0tB+EE9TbICkwssjiFc71FEBEh4K9grKQ==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -734,7 +734,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.609.0"
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
       }
     },
     "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
@@ -760,13 +760,13 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.609.0.tgz",
-      "integrity": "sha512-Rh+3V8dOvEeE1aQmUy904DYWtLUEJ7Vf5XBPlQ6At3pBhp+zpXbsnpZzVL33c8lW1xfj6YPwtO6gOeEsl1juCQ==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
+      "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-endpoints": "^2.0.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -811,12 +811,12 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.609.0.tgz",
-      "integrity": "sha512-DlZBwQ/HkZyf3pOWc7+wjJRk5R7x9YxHhs2szHwtv1IW30KMabjjjX0GMlGJ9LLkBHkbaaEY/w9Tkj12XRLhRg==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2245,11 +2245,11 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.4.tgz",
-      "integrity": "sha512-VwiOk7TwXoE7NlNguV/aPq1hFH72tqkHCw8eWXbr2xHspRyyv9DLpLXhq+Ieje+NwoqXrY0xyQjPXdOE6cGcHA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "@smithy/util-config-provider": "^3.0.0",
         "@smithy/util-middleware": "^3.0.3",
@@ -2265,15 +2265,15 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@smithy/core": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.5.tgz",
-      "integrity": "sha512-0kqyj93/Aa30TEXnnWRBetN8fDGjFF+u8cdIiMI8YS6CrUF2dLTavRfHKfWh5cL5d6s2ZNyEnLjBitdcKmkETQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.6.tgz",
+      "integrity": "sha512-tBbVIv/ui7/lLTKayYJJvi8JLVL2SwOQTbNFEOrvzSE3ktByvsa1erwBOnAMo8N5Vu30g7lN4lLStrU75oDGuw==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.8",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.9",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.6",
+        "@smithy/smithy-client": "^3.1.7",
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
         "tslib": "^2.6.2"
@@ -2288,11 +2288,11 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.3.tgz",
-      "integrity": "sha512-U1Yrv6hx/mRK6k8AncuI6jLUx9rn0VVSd9NPEX6pyYFBfkSkChOc/n4zUb8alHUVg83TbI4OdZVo1X0Zfj3ijA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.4.tgz",
+      "integrity": "sha512-NKyH01m97Xa5xf3pB2QOF3lnuE8RIK0hTVNU5zvZAwZU8uspYO4DHQVlK+Y5gwSrujTfHvbfd1D9UFJAc0iYKQ==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
@@ -2403,13 +2403,13 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.4.tgz",
-      "integrity": "sha512-whUJMEPwl3ANIbXjBXZVdJNgfV2ZU8ayln7xUM47rXL2txuenI7jQ/VFFwCzy5lCmXScjp6zYtptW5Evud8e9g==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
+      "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
       "dependencies": {
         "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-middleware": "^3.0.3",
@@ -2425,14 +2425,14 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.8.tgz",
-      "integrity": "sha512-wmIw3t6ZbeqstUFdXtStzSSltoYrcfc28ndnr0mDSMmtMSRNduNbmneA7xiE224fVFXzbf24+0oREks1u2X7Mw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.9.tgz",
+      "integrity": "sha512-Mrv9omExU1gA7Y0VEJG2LieGfPYtwwcEiOnVGZ54a37NEMr66TJ0glFslOJFuKWG6izg5DpKIUmDV9rRxjm47Q==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/protocol-http": "^4.0.3",
         "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/smithy-client": "^3.1.6",
+        "@smithy/smithy-client": "^3.1.7",
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -2483,12 +2483,12 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.3.tgz",
-      "integrity": "sha512-rxdpAZczzholz6CYZxtqDu/aKTxATD5DAUDVj7HoEulq+pDSQVWzbg0btZDlxeFfa6bb2b5tUvgdX5+k8jUqcg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
       "dependencies": {
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2602,9 +2602,9 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.3.tgz",
-      "integrity": "sha512-Z8Y3+08vgoDgl4HENqNnnzSISAaGrF2RoKupoC47u2wiMp+Z8P/8mDh1CL8+8ujfi2U5naNvopSBmP/BUj8b5w==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
       "dependencies": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -2641,11 +2641,11 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.6.tgz",
-      "integrity": "sha512-w9oboI661hfptr26houZ5mdKc//DMxkuOMXSaIiALqGn4bHYT9S4U69BBS6tHX4TZHgShmhcz0d6aXk7FY5soA==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.7.tgz",
+      "integrity": "sha512-nZbJZB0XI3YnaFBWGDBr7kjaew6O0oNYNmopyIz6gKZEbxzrtH7rwvU1GcVxcSFoOwWecLJEe79fxEMljHopFQ==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/protocol-http": "^4.0.3",
         "@smithy/types": "^3.3.0",
@@ -2769,12 +2769,12 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.8.tgz",
-      "integrity": "sha512-eLRHCvM1w3ZJkYcd60yKqM3d70dPB+071EDpf9ZGYqFed3xcm/+pWwNS/xM0JXRrjm0yAA19dWcdFN2IE/66pQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.9.tgz",
+      "integrity": "sha512-WKPcElz92MAQG09miBdb0GxEH/MwD5GfE8g07WokITq5g6J1ROQfYCKC1wNnkqAGfrSywT7L0rdvvqlBplqiyA==",
       "dependencies": {
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.6",
+        "@smithy/smithy-client": "^3.1.7",
         "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -2789,15 +2789,15 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.8.tgz",
-      "integrity": "sha512-Tajvdyg5+k77j6AOrwSCZgi7KdBizqPNs3HCnFGRoxDjzh+CjPLaLrXbIRB0lsAmqYmRHIU34IogByaqvDrkBQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.9.tgz",
+      "integrity": "sha512-dQLrUqFxqpf0GvEKEuFdgXcdZwz6oFm752h4d6C7lQz+RLddf761L2r7dSwGWzESMMB3wKj0jL+skRhEGlecjw==",
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/credential-provider-imds": "^3.1.3",
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.6",
+        "@smithy/smithy-client": "^3.1.7",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2811,11 +2811,11 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.4.tgz",
-      "integrity": "sha512-ZAtNf+vXAsgzgRutDDiklU09ZzZiiV/nATyqde4Um4priTmasDH+eLpp3tspL0hS2dEootyFMhu1Y6Y+tzpWBQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
+      "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -177,11 +177,11 @@
     "typescript": "^5.5.2"
   },
   "dependencies": {
-    "@aws-sdk/client-sqs": "^3.609.0",
+    "@aws-sdk/client-sqs": "^3.614.0",
     "debug": "^4.3.5"
   },
   "peerDependencies": {
-    "@aws-sdk/client-sqs": "^3.609.0"
+    "@aws-sdk/client-sqs": "^3.614.0"
   },
   "mocha": {
     "extensions": [


### PR DESCRIPTION
Resolves #509

**Description:**

This change ensures that users are downloading the new AWS SDK versions with the bug fixes for the memory leak issues.
