### PR TITLE
chore: removing aws sdk v2 note

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,6 @@ npm install sqs-consumer
 
 If you would like to use JSR instead, you can find the package [here](https://jsr.io/@bbc/sqs-consumer).
 
-> **Note**
-> This library assumes you are using [AWS SDK v3](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-sqs/index.html). If you are using v2, please install v5.8.0:
->
-> ```bash
-> npm install sqs-consumer@5.8.0
-> ```
-
 ### Node version
 
 We will only support Node versions that are actively or security supported by the Node team. If you are still using an Node 14, please use a version of this library before the v7 release, if you are using Node 16, please use a version before the v7.3.0 release.


### PR DESCRIPTION
Resolves #462

**Description:**

As aws sdk v2 is now in maintenance support rather than active support, we have decided to remove the note linking to the version of sqs-consumer that supported that version, this is due to us being unable to support packages not in an active state.
