### PR TITLE
feat: terminateVisibilityTimeout = number to customise the timeout

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -51,7 +51,7 @@ export class Consumer extends TypedEventEmitter {
   private alwaysAcknowledge: boolean;
   private batchSize: number;
   private visibilityTimeout: number;
-  private terminateVisibilityTimeout: boolean;
+  private terminateVisibilityTimeout: boolean | number;
   private waitTimeSeconds: number;
   private authenticationErrorTimeout: number;
   private pollingWaitTimeMs: number;
@@ -362,8 +362,12 @@ export class Consumer extends TypedEventEmitter {
     } catch (err) {
       this.emitError(err, message);
 
-      if (this.terminateVisibilityTimeout) {
-        await this.changeVisibilityTimeout(message, 0);
+      if (this.terminateVisibilityTimeout !== false) {
+        const timeout =
+          this.terminateVisibilityTimeout === true
+            ? 0
+            : this.terminateVisibilityTimeout;
+        await this.changeVisibilityTimeout(message, timeout);
       }
     } finally {
       if (this.heartbeatInterval) {
@@ -400,8 +404,12 @@ export class Consumer extends TypedEventEmitter {
     } catch (err) {
       this.emit("error", err, messages);
 
-      if (this.terminateVisibilityTimeout) {
-        await this.changeVisibilityTimeoutBatch(messages, 0);
+      if (this.terminateVisibilityTimeout !== false) {
+        const timeout =
+          this.terminateVisibilityTimeout === true
+            ? 0
+            : this.terminateVisibilityTimeout;
+        await this.changeVisibilityTimeoutBatch(messages, timeout);
       }
     } finally {
       clearInterval(heartbeatTimeoutId);

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,10 +66,11 @@ export interface ConsumerOptions {
    */
   pollingCompleteWaitTimeMs?: number;
   /**
-   * If true, sets the message visibility timeout to 0 after a `processing_error`.
+   * If true, sets the message visibility timeout to 0 after a `processing_error`. You can
+   * also specify a different timeout using a number.
    * @defaultvalue `false`
    */
-  terminateVisibilityTimeout?: boolean;
+  terminateVisibilityTimeout?: boolean | number;
   /**
    * The interval (in seconds) between requests to extend the message visibility timeout.
    *


### PR DESCRIPTION
Resolves #523

**Description:**
This allows users to introduce a delay before the message can be received again. In some cases this can improve the overall success rate.

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
When tasks are not time critical, a small delay can mitigate some intermittent errors, or give supervisors like K8s a little time to kill broken consumers.

**Code changes:**

- `terminateVisibilityTimeout` option has been updated to accept custom visibility timeouts.

I reused the option as I thought it was the most non-intrusive way to introduce this feature. If it appears to be confusing, I can also add a new option. But since the underlying SQS command is the same, I think it's ok.

---

**Checklist:**

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
