### PR TITLE
feat: append more context to errors from the consumer 

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -315,7 +315,7 @@ export class Consumer extends TypedEventEmitter {
         err,
         `SQS receive message failed: ${err.message}`,
         this.extendedAWSErrors,
-        this.queueUrl
+        this.queueUrl,
       );
     }
   }
@@ -481,7 +481,7 @@ export class Consumer extends TypedEventEmitter {
           `Error changing visibility timeout: ${err.message}`,
           this.extendedAWSErrors,
           this.queueUrl,
-          message
+          message,
         ),
         message,
       );
@@ -518,7 +518,7 @@ export class Consumer extends TypedEventEmitter {
           `Error changing visibility timeout: ${err.message}`,
           this.extendedAWSErrors,
           this.queueUrl,
-          messages
+          messages,
         ),
         messages,
       );
@@ -625,7 +625,7 @@ export class Consumer extends TypedEventEmitter {
         `SQS delete message failed: ${err.message}`,
         this.extendedAWSErrors,
         this.queueUrl,
-        message
+        message,
       );
     }
   }
@@ -665,7 +665,7 @@ export class Consumer extends TypedEventEmitter {
         `SQS delete message failed: ${err.message}`,
         this.extendedAWSErrors,
         this.queueUrl,
-        messages
+        messages,
       );
     }
   }

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -315,6 +315,7 @@ export class Consumer extends TypedEventEmitter {
         err,
         `SQS receive message failed: ${err.message}`,
         this.extendedAWSErrors,
+        this.queueUrl
       );
     }
   }
@@ -479,6 +480,8 @@ export class Consumer extends TypedEventEmitter {
           err,
           `Error changing visibility timeout: ${err.message}`,
           this.extendedAWSErrors,
+          this.queueUrl,
+          message
         ),
         message,
       );
@@ -514,6 +517,8 @@ export class Consumer extends TypedEventEmitter {
           err,
           `Error changing visibility timeout: ${err.message}`,
           this.extendedAWSErrors,
+          this.queueUrl,
+          messages
         ),
         messages,
       );
@@ -619,6 +624,8 @@ export class Consumer extends TypedEventEmitter {
         err,
         `SQS delete message failed: ${err.message}`,
         this.extendedAWSErrors,
+        this.queueUrl,
+        message
       );
     }
   }
@@ -657,6 +664,8 @@ export class Consumer extends TypedEventEmitter {
         err,
         `SQS delete message failed: ${err.message}`,
         this.extendedAWSErrors,
+        this.queueUrl,
+        messages
       );
     }
   }

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -549,14 +549,14 @@ export class Consumer extends TypedEventEmitter {
         throw toTimeoutError(
           err,
           `Message handler timed out after ${this.handleMessageTimeout}ms: Operation timed out.`,
-          message
+          message,
         );
       }
       if (err instanceof Error) {
         throw toStandardError(
           err,
           `Unexpected message handler failure: ${err.message}`,
-          message
+          message,
         );
       }
       throw err;

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -549,12 +549,14 @@ export class Consumer extends TypedEventEmitter {
         throw toTimeoutError(
           err,
           `Message handler timed out after ${this.handleMessageTimeout}ms: Operation timed out.`,
+          message
         );
       }
       if (err instanceof Error) {
         throw toStandardError(
           err,
           `Unexpected message handler failure: ${err.message}`,
+          message
         );
       }
       throw err;
@@ -581,6 +583,7 @@ export class Consumer extends TypedEventEmitter {
         throw toStandardError(
           err,
           `Unexpected message handler failure: ${err.message}`,
+          messages,
         );
       }
       throw err;

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -1675,6 +1675,8 @@ describe("Consumer", () => {
 
       assert.ok(err);
       assert.equal(err.message, "Error changing visibility timeout: failed");
+      assert.equal(err.queueUrl, QUEUE_URL);
+      assert.deepEqual(err.messageIds, ["1"]);
     });
 
     it("emit error when changing visibility timeout fails for batch handler functions", async () => {
@@ -1707,6 +1709,8 @@ describe("Consumer", () => {
 
       assert.ok(err);
       assert.equal(err.message, "Error changing visibility timeout: failed");
+      assert.equal(err.queueUrl, QUEUE_URL);
+      assert.deepEqual(err.messageIds, ["1", "2"]);
     });
 
     it("includes messageIds in timeout errors", async () => {
@@ -1767,6 +1771,93 @@ describe("Consumer", () => {
         err.message,
         "Unexpected message handler failure: Batch processing error",
       );
+      assert.deepEqual(err.messageIds, ["1", "2"]);
+    });
+
+    it("includes queueUrl and messageIds in SQS errors when deleting message", async () => {
+      const deleteErr = new Error("Delete error");
+      deleteErr.name = "SQSError";
+
+      handleMessage.resolves(null);
+      sqs.send.withArgs(mockDeleteMessage).rejects(deleteErr);
+
+      consumer.start();
+      const [err]: any = await Promise.all([
+        pEvent(consumer, "error"),
+        clock.tickAsync(100),
+      ]);
+      consumer.stop();
+
+      assert.ok(err);
+      assert.equal(err.message, "SQS delete message failed: Delete error");
+      assert.equal(err.queueUrl, QUEUE_URL);
+      assert.deepEqual(err.messageIds, ["123"]);
+    });
+
+    it("includes queueUrl and messageIds in SQS errors when changing visibility timeout", async () => {
+      sqs.send.withArgs(mockReceiveMessage).resolves({
+        Messages: [
+          { MessageId: "1", ReceiptHandle: "receipt-handle-1", Body: "body-1" },
+        ],
+      });
+      consumer = new Consumer({
+        queueUrl: QUEUE_URL,
+        region: REGION,
+        handleMessage: () =>
+          new Promise((resolve) => setTimeout(resolve, 75000)),
+        sqs,
+        visibilityTimeout: 40,
+        heartbeatInterval: 30,
+      });
+
+      const receiveErr = new MockSQSError("failed");
+      sqs.send.withArgs(mockChangeMessageVisibility).rejects(receiveErr);
+
+      consumer.start();
+      const [err]: any = await Promise.all([
+        pEvent(consumer, "error"),
+        clock.tickAsync(75000),
+      ]);
+      consumer.stop();
+
+      assert.ok(err);
+      assert.equal(err.message, "Error changing visibility timeout: failed");
+      assert.equal(err.queueUrl, QUEUE_URL);
+      assert.deepEqual(err.messageIds, ["1"]);
+    });
+
+    it("includes queueUrl and messageIds in batch SQS errors", async () => {
+      sqs.send.withArgs(mockReceiveMessage).resolves({
+        Messages: [
+          { MessageId: "1", ReceiptHandle: "receipt-handle-1", Body: "body-1" },
+          { MessageId: "2", ReceiptHandle: "receipt-handle-2", Body: "body-2" },
+        ],
+      });
+
+      consumer = new Consumer({
+        queueUrl: QUEUE_URL,
+        region: REGION,
+        handleMessageBatch: () =>
+          new Promise((resolve) => setTimeout(resolve, 75000)),
+        sqs,
+        batchSize: 2,
+        visibilityTimeout: 40,
+        heartbeatInterval: 30,
+      });
+
+      const receiveErr = new MockSQSError("failed");
+      sqs.send.withArgs(mockChangeMessageVisibilityBatch).rejects(receiveErr);
+
+      consumer.start();
+      const [err]: any = await Promise.all([
+        pEvent(consumer, "error"),
+        clock.tickAsync(75000),
+      ]);
+      consumer.stop();
+
+      assert.ok(err);
+      assert.equal(err.message, "Error changing visibility timeout: failed");
+      assert.equal(err.queueUrl, QUEUE_URL);
       assert.deepEqual(err.messageIds, ["1", "2"]);
     });
   });

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -1765,7 +1765,7 @@ describe("Consumer", () => {
       assert.ok(err);
       assert.equal(
         err.message,
-        "Unexpected message handler failure: Batch processing error"
+        "Unexpected message handler failure: Batch processing error",
       );
       assert.deepEqual(err.messageIds, ["1", "2"]);
     });


### PR DESCRIPTION
This appends messageIds to the errors that are thrown by standard and timeout errors, this should make it easier to debug these errors.

This also appends the queueUrl to sqsErrors, alongside the messages if available.