### PR TITLE
feat: send the queueUrl alongside emitted events

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -41,7 +41,7 @@ import { logger } from "./logger.js";
 export class Consumer extends TypedEventEmitter {
   private pollingTimeoutId: NodeJS.Timeout | undefined = undefined;
   private stopped = true;
-  private queueUrl: string;
+  protected queueUrl: string;
   private handleMessage: (message: Message) => Promise<Message | void>;
   private handleMessageBatch: (message: Message[]) => Promise<Message[] | void>;
   private preReceiveMessageCallback?: () => Promise<void>;
@@ -70,7 +70,7 @@ export class Consumer extends TypedEventEmitter {
   private extendedAWSErrors: boolean;
 
   constructor(options: ConsumerOptions) {
-    super();
+    super(options.queueUrl);
     assertOptions(options);
     this.queueUrl = options.queueUrl;
     this.handleMessage = options.handleMessage;

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -4,6 +4,13 @@ import { logger } from "./logger.js";
 import { Events } from "./types.js";
 
 export class TypedEventEmitter extends EventEmitter {
+  protected queueUrl?: string;
+
+  constructor(queueUrl?: string) {
+    super();
+    this.queueUrl = queueUrl;
+  }
+
   /**
    * Trigger a listener on all emitted events
    * @param event The name of the event to listen to
@@ -31,7 +38,7 @@ export class TypedEventEmitter extends EventEmitter {
    * @param event The name of the event to emit
    */
   emit<E extends keyof Events>(event: E, ...args: Events[E]): boolean {
-    logger.debug(event, ...args);
-    return super.emit(event, ...args);
+    logger.debug(event, ...args, { queueUrl: this.queueUrl });
+    return super.emit(event, ...args, { queueUrl: this.queueUrl });
   }
 }

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -6,6 +6,9 @@ import { Events, QueueMetadata } from "./types.js";
 export class TypedEventEmitter extends EventEmitter {
   protected queueUrl?: string;
 
+  /**
+   * @param queueUrl - The URL of the SQS queue this emitter is associated with
+   */
   constructor(queueUrl?: string) {
     super();
     this.queueUrl = queueUrl;
@@ -36,10 +39,13 @@ export class TypedEventEmitter extends EventEmitter {
   }
 
   /**
-   * Emits an event with the provided arguments
+   * Emits an event with the provided arguments and adds queue metadata
    * @param event The name of the event to emit
    * @param args The arguments to pass to the event listeners
    * @returns {boolean} Returns true if the event had listeners, false otherwise
+   * @example
+   * // Inside a method:
+   * this.emit('message_received', message);
    */
   emit<E extends keyof Events>(event: E, ...args: Events[E]): boolean {
     const metadata: QueueMetadata = { queueUrl: this.queueUrl };

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "node:events";
 
 import { logger } from "./logger.js";
-import { Events } from "./types.js";
+import { Events, QueueMetadata } from "./types.js";
 
 export class TypedEventEmitter extends EventEmitter {
   protected queueUrl?: string;
@@ -18,10 +18,11 @@ export class TypedEventEmitter extends EventEmitter {
    */
   on<E extends keyof Events>(
     event: E,
-    listener: (...args: Events[E]) => void,
+    listener: (...args: [...Events[E], QueueMetadata]) => void,
   ): this {
     return super.on(event, listener);
   }
+
   /**
    * Trigger a listener only once for an emitted event
    * @param event The name of the event to listen to
@@ -29,10 +30,11 @@ export class TypedEventEmitter extends EventEmitter {
    */
   once<E extends keyof Events>(
     event: E,
-    listener: (...args: Events[E]) => void,
+    listener: (...args: [...Events[E], QueueMetadata]) => void,
   ): this {
     return super.once(event, listener);
   }
+
   /**
    * Emits an event with the provided arguments
    * @param event The name of the event to emit
@@ -40,7 +42,8 @@ export class TypedEventEmitter extends EventEmitter {
    * @returns {boolean} Returns true if the event had listeners, false otherwise
    */
   emit<E extends keyof Events>(event: E, ...args: Events[E]): boolean {
-    logger.debug(event, ...args, { queueUrl: this.queueUrl });
-    return super.emit(event, ...args, { queueUrl: this.queueUrl });
+    const metadata: QueueMetadata = { queueUrl: this.queueUrl };
+    logger.debug(event, ...args, metadata);
+    return super.emit(event, ...args, metadata);
   }
 }

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -36,6 +36,8 @@ export class TypedEventEmitter extends EventEmitter {
   /**
    * Emits an event with the provided arguments
    * @param event The name of the event to emit
+   * @param args The arguments to pass to the event listeners
+   * @returns {boolean} Returns true if the event had listeners, false otherwise
    */
   emit<E extends keyof Events>(event: E, ...args: Events[E]): boolean {
     logger.debug(event, ...args, { queueUrl: this.queueUrl });

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,7 +189,7 @@ export interface StopOptions {
  * Metadata about the queue that is added to every event
  */
 export interface QueueMetadata {
-  queueUrl?: string;
+  queueUrl: string;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,6 +186,13 @@ export interface StopOptions {
 }
 
 /**
+ * Metadata about the queue that is added to every event
+ */
+export interface QueueMetadata {
+  queueUrl?: string;
+}
+
+/**
  * These are the events that the consumer emits.
  */
 export interface Events {

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,11 +189,17 @@ export interface StopOptions {
  * Metadata about the queue that is added to every event
  */
 export interface QueueMetadata {
-  queueUrl: string;
+  queueUrl?: string;
 }
 
 /**
  * These are the events that the consumer emits.
+ * Each event will receive QueueMetadata as the last argument.
+ * @example
+ * consumer.on('message_received', (message, metadata) => {
+ *   console.log(`Received message from queue: ${metadata.queueUrl}`);
+ *   console.log(message);
+ * });
  */
 export interface Events {
   /**


### PR DESCRIPTION
This automatically attaches the queueUrl to all emitted events.