### PR TITLE
fix: always emit a message from emitError

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -231,7 +231,7 @@ export class Consumer extends TypedEventEmitter {
    */
   private emitError(err: Error, message?: Message): void {
     if (!message) {
-      this.emit("error", err);
+      this.emit("error", err, undefined);
     } else if (err.name === SQSError.name) {
       this.emit("error", err, message);
     } else if (err instanceof TimeoutError) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -228,7 +228,7 @@ export interface Events {
    *
    * If the error correlates to a message, that message is included in Params
    */
-  error: [Error, (Message | Message[] | undefined)];
+  error: [Error, Message | Message[] | undefined];
   /**
    * Fired when `handleMessageTimeout` is supplied as an option and if
    * `handleMessage` times out.

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,7 +199,7 @@ export interface QueueMetadata {
 
 /**
  * These are the events that the consumer emits.
- * Each event will receive QueueMetadata as the last argument.
+ * Each event will receive QueueMetadata as the last argument, which is added automatically by the emitter.
  * @example
  * consumer.on('message_received', (message, metadata) => {
  *   console.log(`Received message from queue: ${metadata.queueUrl}`);
@@ -228,7 +228,7 @@ export interface Events {
    *
    * If the error correlates to a message, that message is included in Params
    */
-  error: [Error, void | Message | Message[]];
+  error: [Error, (Message | Message[] | undefined)];
   /**
    * Fired when `handleMessageTimeout` is supplied as an option and if
    * `handleMessage` times out.

--- a/test/features/events.feature
+++ b/test/features/events.feature
@@ -1,0 +1,33 @@
+Feature: Events are emitted with the correct parameters and metadata
+
+  Scenario: Error event without a message is emitted with undefined as the second parameter
+    Given a consumer that will encounter an error without a message
+    When the consumer starts
+    Then an error event should be emitted with undefined as the second parameter
+    And the event should include metadata with queueUrl
+
+  Scenario: Error event with a message is emitted with the message as the second parameter
+    Given a test message is sent to the SQS queue for events test
+    And a consumer that will encounter an error with a message
+    When the consumer starts
+    Then an error event should be emitted with the message as the second parameter
+    And the event should include metadata with queueUrl
+
+  Scenario: Message events are emitted with metadata
+    Given a test message is sent to the SQS queue for events test
+    And a consumer that processes messages normally
+    When the consumer starts
+    Then message_received event should be emitted with metadata
+    And message_processed event should be emitted with metadata
+
+  Scenario: Empty queue event is emitted with metadata
+    Given an empty SQS queue
+    And a consumer that processes messages normally
+    When the consumer polls an empty queue
+    Then empty event should be emitted with metadata
+
+  Scenario: Started and stopped events are emitted with metadata
+    Given a consumer that processes messages normally
+    When the consumer starts and stops
+    Then started event should be emitted with metadata
+    And stopped event should be emitted with metadata 

--- a/test/features/step_definitions/events.js
+++ b/test/features/step_definitions/events.js
@@ -1,0 +1,257 @@
+/* eslint-disable no-undefined -- This is a test file */
+
+import { Given, When, Then, After } from "@cucumber/cucumber";
+import { strictEqual, ok, deepStrictEqual } from "node:assert";
+import { PurgeQueueCommand } from "@aws-sdk/client-sqs";
+import { pEvent } from "p-event";
+
+import { Consumer } from "../../../dist/esm/consumer.js";
+import { producer } from "../utils/producer.js";
+import { sqs, QUEUE_URL } from "../utils/sqs.js";
+
+let consumer;
+let errorEvent;
+let messageParam;
+let metadataParam;
+let receivedEvents = {};
+
+Given("a consumer that will encounter an error without a message", () => {
+  const mockSqs = {
+    send() {
+      throw new Error("Receive error");
+    },
+  };
+
+  consumer = new Consumer({
+    queueUrl: QUEUE_URL,
+    sqs: mockSqs,
+    handleMessage: async (message) => message,
+  });
+
+  consumer.on("error", (err, message, metadata) => {
+    errorEvent = err;
+    messageParam = message;
+    metadataParam = metadata;
+  });
+});
+
+Given("a consumer that will encounter an error with a message", () => {
+  const mockSqs = {
+    send(command) {
+      if (command.constructor.name === "DeleteMessageCommand") {
+        const error = new Error("Delete error");
+        error.name = "SQSError";
+        throw error;
+      }
+      return sqs.send(command);
+    },
+  };
+
+  consumer = new Consumer({
+    queueUrl: QUEUE_URL,
+    sqs: mockSqs,
+    handleMessage: async (message) => message,
+  });
+
+  consumer.on("error", (err, message, metadata) => {
+    errorEvent = err;
+    messageParam = message;
+    metadataParam = metadata;
+  });
+});
+
+Given("a consumer that processes messages normally", () => {
+  consumer = new Consumer({
+    queueUrl: QUEUE_URL,
+    sqs,
+    handleMessage: async (message) => message,
+    pollingWaitTimeMs: 100,
+    waitTimeSeconds: 1,
+  });
+
+  [
+    "message_received",
+    "message_processed",
+    "empty",
+    "started",
+    "stopped",
+  ].forEach((eventName) => {
+    consumer.on(eventName, (...args) => {
+      const metadata = args.at(-1);
+      receivedEvents[eventName] = {
+        args,
+        metadata,
+      };
+    });
+  });
+});
+
+Given("a test message is sent to the SQS queue for events test", async () => {
+  await producer.send("test-message-for-events");
+});
+
+Given("an empty SQS queue", async () => {
+  await sqs.send(new PurgeQueueCommand({ QueueUrl: QUEUE_URL }));
+});
+
+When("the consumer starts", async () => {
+  consumer.start();
+  strictEqual(consumer.status.isRunning, true);
+
+  try {
+    if (!errorEvent) {
+      await Promise.race([
+        pEvent(consumer, "error", { timeout: 3000 }),
+        new Promise((resolve) => setTimeout(resolve, 3000)),
+      ]);
+    } else {
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+    }
+  } catch {
+    // Timeout is expected in some cases
+  }
+
+  consumer.stop();
+  strictEqual(consumer.status.isRunning, false);
+});
+
+When("the consumer polls an empty queue", async () => {
+  consumer.start();
+  strictEqual(consumer.status.isRunning, true);
+
+  try {
+    await pEvent(consumer, "empty", { timeout: 10000 });
+  } catch {
+    // If timeout occurs, we'll check if the event was registered anyway
+  }
+
+  consumer.stop();
+  strictEqual(consumer.status.isRunning, false);
+});
+
+When("the consumer starts and stops", async () => {
+  try {
+    consumer.start();
+    strictEqual(consumer.status.isRunning, true);
+
+    await Promise.race([
+      pEvent(consumer, "started", { timeout: 2000 }),
+      new Promise((resolve) => setTimeout(resolve, 2000)),
+    ]);
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    consumer.stop();
+
+    await Promise.race([
+      pEvent(consumer, "stopped", { timeout: 2000 }),
+      new Promise((resolve) => setTimeout(resolve, 2000)),
+    ]);
+
+    strictEqual(consumer.status.isRunning, false);
+  } catch {
+    consumer.stop();
+  }
+});
+
+Then(
+  "an error event should be emitted with undefined as the second parameter",
+  () => {
+    ok(errorEvent, "Error event should be defined");
+    strictEqual(
+      messageParam,
+      undefined,
+      "Message parameter should be undefined",
+    );
+  },
+);
+
+Then(
+  "an error event should be emitted with the message as the second parameter",
+  () => {
+    ok(errorEvent, "Error event should be defined");
+    ok(messageParam, "Message parameter should be defined");
+    ok(messageParam.MessageId, "Message should have an ID");
+    ok(messageParam.Body, "Message should have a body");
+  },
+);
+
+Then("the event should include metadata with queueUrl", () => {
+  deepStrictEqual(
+    metadataParam,
+    { queueUrl: QUEUE_URL },
+    "Metadata should contain the queue URL",
+  );
+});
+
+Then("message_received event should be emitted with metadata", () => {
+  ok(
+    receivedEvents.message_received,
+    "message_received event should be emitted",
+  );
+  ok(
+    receivedEvents.message_received.args.length > 0,
+    "message_received event should have arguments",
+  );
+  deepStrictEqual(
+    receivedEvents.message_received.metadata,
+    { queueUrl: QUEUE_URL },
+    "message_received metadata should contain the queue URL",
+  );
+});
+
+Then("message_processed event should be emitted with metadata", () => {
+  ok(
+    receivedEvents.message_processed,
+    "message_processed event should be emitted",
+  );
+  ok(
+    receivedEvents.message_processed.args.length > 0,
+    "message_processed event should have arguments",
+  );
+  deepStrictEqual(
+    receivedEvents.message_processed.metadata,
+    { queueUrl: QUEUE_URL },
+    "message_processed metadata should contain the queue URL",
+  );
+});
+
+Then("empty event should be emitted with metadata", () => {
+  ok(receivedEvents.empty, "empty event should be emitted");
+  deepStrictEqual(
+    receivedEvents.empty.metadata,
+    { queueUrl: QUEUE_URL },
+    "empty event metadata should contain the queue URL",
+  );
+});
+
+Then("started event should be emitted with metadata", () => {
+  ok(receivedEvents.started, "started event should be emitted");
+  deepStrictEqual(
+    receivedEvents.started.metadata,
+    { queueUrl: QUEUE_URL },
+    "started event metadata should contain the queue URL",
+  );
+});
+
+Then("stopped event should be emitted with metadata", () => {
+  ok(receivedEvents.stopped, "stopped event should be emitted");
+  deepStrictEqual(
+    receivedEvents.stopped.metadata,
+    { queueUrl: QUEUE_URL },
+    "stopped event metadata should contain the queue URL",
+  );
+});
+
+After(() => {
+  if (consumer && consumer.status.isRunning) {
+    consumer.stop();
+  }
+
+  errorEvent = undefined;
+  messageParam = undefined;
+  metadataParam = undefined;
+  receivedEvents = {};
+});
+
+/* eslint-enable no-undefined -- This is a test file */

--- a/test/features/step_definitions/gracefulShutdown.js
+++ b/test/features/step_definitions/gracefulShutdown.js
@@ -16,15 +16,19 @@ Given("Several messages are sent to the SQS queue", async () => {
 
   strictEqual(response.$metadata.httpStatusCode, 200);
 
-  await new Promise(resolve => setTimeout(resolve, 1000));
+  await new Promise((resolve) => setTimeout(resolve, 1000));
 
   const size = await producer.queueSize();
-  
+
   if (size > 0) {
     await sqs.send(command);
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     const sizeAfterSecondPurge = await producer.queueSize();
-    strictEqual(sizeAfterSecondPurge, 0, "Queue should be empty after second purge");
+    strictEqual(
+      sizeAfterSecondPurge,
+      0,
+      "Queue should be empty after second purge",
+    );
   } else {
     strictEqual(size, 0, "Queue should be empty after purge");
   }
@@ -62,6 +66,6 @@ Then(
 
 After(async () => {
   consumer.stop();
-  
+
   await sqs.send(new PurgeQueueCommand({ QueueUrl: QUEUE_URL }));
 });

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -1882,17 +1882,13 @@ describe("Consumer", () => {
     });
 
     it("includes undefined in error event when poll method catches an error", async () => {
-      // Create a special error for this test
       const pollError = new Error("Poll error");
 
-      // Make receiveMessage succeed
       sqs.send.withArgs(mockReceiveMessage).resolves({});
 
-      // Stub handleSqsResponse to throw an error
       const originalPrototype = Object.getPrototypeOf(consumer);
       const originalHandleSqsResponse = originalPrototype.handleSqsResponse;
 
-      // Use Object.defineProperty to override the private method
       Object.defineProperty(originalPrototype, "handleSqsResponse", {
         value: sandbox.stub().throws(pollError),
       });
@@ -1904,7 +1900,6 @@ describe("Consumer", () => {
       await pEvent(consumer, "error");
       consumer.stop();
 
-      // Restore original method
       Object.defineProperty(originalPrototype, "handleSqsResponse", {
         value: originalHandleSqsResponse,
       });


### PR DESCRIPTION
Resolves #564

**Description:**

As described in the issue, https://github.com/bbc/sqs-consumer/pull/560 made a change that meant that all emitted events always included metadata as the last parameter, this meant that `message` was no longer the second parameter in error events which breaks some handling for users who where using that method to get the message details.

**Type of change:**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

This ensures that the change is backwards compatible by making `emitError` emit undefined as the second parameter if messages were not provided to it.

NOTE: This does changed the type from setting `void` in the return union for the error emitted to event to be more explicitly `undefined`