### PR TITLE
feat: export error classes

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -159,6 +159,7 @@ function toTimeoutError(
 
 export {
   SQSError,
+  StandardError,
   TimeoutError,
   isConnectionError,
   toSQSError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { Consumer } from "./consumer.js";
+export { SQSError, StandardError, TimeoutError } from "./errors.js";
 export * from "./types.js";


### PR DESCRIPTION
Resolves #563

This exports the error classes SQSError, StandardError, TimeoutError which would enable users to create logic that uses them more easily, without having to recreate / maintain their own versions.