### PR TITLE
feat(breaking): do not acknowledge if void is returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,16 @@ app.on("processing_error", (err) => {
 app.start();
 ```
 
-- The queue is polled continuously for messages using [long polling](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html).
-- Throwing an error (or returning a rejected promise) from the handler function will cause the message to be left on the queue. An [SQS redrive policy](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html) can be used to move messages that cannot be processed to a dead letter queue.
-- By default messages are processed one at a time – a new message won't be received until the first one has been processed. To process messages in parallel, use the `batchSize` option [detailed here](https://bbc.github.io/sqs-consumer/interfaces/ConsumerOptions.html#batchSize).
+- **Polling Behavior**: The queue is polled continuously for messages using [long polling](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html).
+- **Message Processing Behavior**: By default messages are processed one at a time – a new message won't be received until the first one has been processed. To process messages in parallel, use the `batchSize` option [detailed here](https://bbc.github.io/sqs-consumer/interfaces/ConsumerOptions.html#batchSize).
   - It's also important to await any processing that you are doing to ensure that messages are processed one at a time.
-- By default, messages that are sent to the `handleMessage` and `handleMessageBatch` functions will be considered as processed if they return without an error.
-  - To acknowledge individual messages, please return the message that you want to acknowledge if you are using `handleMessage` or the messages for `handleMessageBatch`.
-    - To note, returning an empty object or an empty array will be considered an acknowledgement of no message(s) and will result in no messages being deleted. If you would like to change this behaviour, please use the `alwaysAcknowledge` option [detailed here](https://bbc.github.io/sqs-consumer/interfaces/ConsumerOptions.html).
-    - By default, if an object or an array is not returned, all messages will be acknowledged.
-- Messages are deleted from the queue once the handler function has completed successfully (the above items should also be taken into account).
+- **Message Acknowledgment Behavior** (when `alwaysAcknowledge` is `false` - the default):
+  - **Returning `undefined` or `void`**: Message will **NOT** be deleted (left on queue for retry)
+  - **Returning an empty object `{}`**: Message will **NOT** be deleted
+  - **Returning the message object or an array of messages in batch processing**: Message(s) will be **acknowledged and deleted**
+  - **When `alwaysAcknowledge` is `true`:** All messages will be acknowledged and deleted regardless of return value.
+- **Error Handling**: Throwing an error (or returning a rejected promise) from the handler function will cause the message to be left on the queue. An [SQS redrive policy](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html) can be used to move messages that cannot be processed to a dead letter queue.
+- **Deletion Process** Messages are deleted from the queue once the handler function has completed successfully (the above items should also be taken into account).
 
 ### FIFO Queue Support
 

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -555,9 +555,16 @@ export class Consumer extends TypedEventEmitter {
         result = await this.handleMessage(message);
       }
 
-      return !this.alwaysAcknowledge && result instanceof Object
-        ? result
-        : message;
+
+      if (this.alwaysAcknowledge) {
+        return message;
+      }
+
+      if (result instanceof Object) {
+        return result;
+      }
+
+      return null;
     } catch (err) {
       if (err instanceof TimeoutError) {
         throw toTimeoutError(
@@ -589,9 +596,16 @@ export class Consumer extends TypedEventEmitter {
     try {
       const result: void | Message[] = await this.handleMessageBatch(messages);
 
-      return !this.alwaysAcknowledge && result instanceof Object
-        ? result
-        : messages;
+
+      if (this.alwaysAcknowledge) {
+        return messages;
+      }
+
+      if (Array.isArray(result)) {
+        return result;
+      }
+
+      return [];
     } catch (err) {
       if (err instanceof Error) {
         throw toStandardError(

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -555,7 +555,6 @@ export class Consumer extends TypedEventEmitter {
         result = await this.handleMessage(message);
       }
 
-
       if (this.alwaysAcknowledge) {
         return message;
       }
@@ -595,7 +594,6 @@ export class Consumer extends TypedEventEmitter {
   private async executeBatchHandler(messages: Message[]): Promise<Message[]> {
     try {
       const result: void | Message[] = await this.handleMessageBatch(messages);
-
 
       if (this.alwaysAcknowledge) {
         return messages;

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,8 +126,13 @@ export interface ConsumerOptions {
    * An `async` function (or function that returns a `Promise`) to be called whenever
    * a message is received.
    *
-   * In the case that you need to acknowledge the message, return an object containing
-   * the MessageId that you'd like to acknowledge.
+   * **Message Acknowledgment Behavior:**
+   * - Returning `undefined` or `void` will **NOT acknowledge** the message (leaves it on queue for retry)
+   * - Returning the original message will cause the message to be **acknowledged and deleted**
+   * - To **prevent acknowledgment**, return `undefined` or an empty object `{}`
+   * - To **explicitly acknowledge** a specific message, return an object containing the MessageId you want to acknowledge
+   *
+   * **Important:** If `alwaysAcknowledge` is `true`, all messages will be acknowledged regardless of return value.
    */
   handleMessage?(message: Message): Promise<Message | void>;
   /**
@@ -137,8 +142,13 @@ export interface ConsumerOptions {
    *
    * **If both are set, `handleMessageBatch` overrides `handleMessage`**.
    *
-   * In the case that you need to ack only some of the messages, return an array with
-   * the successful messages only.
+   * **Message Acknowledgment Behavior:**
+   * - Returning `undefined` or `void` will **NOT acknowledge** any messages (leaves them on queue for retry)
+   * - Returning the original message array will cause **all messages to be acknowledged and deleted**
+   * - To **prevent acknowledgment** of all messages, return `undefined` or an empty array `[]`
+   * - To **selectively acknowledge** messages, return an array containing only the messages you want to acknowledge
+   *
+   * **Important:** If `alwaysAcknowledge` is `true`, all messages will be acknowledged regardless of return value.
    */
   handleMessageBatch?(messages: Message[]): Promise<Message[] | void>;
   /**

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -74,7 +74,7 @@ describe("Consumer", () => {
 
   beforeEach(() => {
     clock = sinon.useFakeTimers();
-    handleMessage = sandbox.stub().resolves(null);
+    handleMessage = sandbox.stub().resolves(response.Messages[0]);
     handleMessageBatch = sandbox.stub().resolves(null);
     sqs = sinon.createStubInstance(SQSClient);
     sqs.send = sinon.stub();
@@ -436,7 +436,7 @@ describe("Consumer", () => {
     it("fires an error event when an error occurs deleting a message", async () => {
       const deleteErr = new Error("Delete error");
 
-      handleMessage.resolves(null);
+      handleMessage.resolves(response.Messages[0]);
       sqs.send.withArgs(mockDeleteMessage).rejects(deleteErr);
 
       consumer.start();
@@ -473,7 +473,7 @@ describe("Consumer", () => {
       const sqsError = new Error("Processing error");
       sqsError.name = "SQSError";
 
-      handleMessage.resolves();
+      handleMessage.resolves(response.Messages[0]);
       sqs.send.withArgs(mockDeleteMessage).rejects(sqsError);
 
       consumer.start();
@@ -780,7 +780,7 @@ describe("Consumer", () => {
     });
 
     it("fires a message_processed event when a message is successfully deleted", async () => {
-      handleMessage.resolves();
+      handleMessage.resolves(response.Messages[0]);
 
       consumer.start();
       const message = await pEvent(consumer, "message_received");
@@ -820,7 +820,7 @@ describe("Consumer", () => {
     });
 
     it("deletes the message when the handleMessage function is called", async () => {
-      handleMessage.resolves();
+      handleMessage.resolves(response.Messages[0]);
 
       consumer.start();
       await pEvent(consumer, "message_processed");
@@ -846,7 +846,7 @@ describe("Consumer", () => {
         shouldDeleteMessages: false,
       });
 
-      handleMessage.resolves();
+      handleMessage.resolves(response.Messages[0]);
 
       consumer.start();
       await pEvent(consumer, "message_processed");
@@ -866,7 +866,7 @@ describe("Consumer", () => {
     });
 
     it("consumes another message once one is processed", async () => {
-      handleMessage.resolves();
+      handleMessage.resolves(response.Messages[0]);
 
       consumer.start();
       await clock.runToLastAsync();
@@ -1156,7 +1156,7 @@ describe("Consumer", () => {
           },
         ],
       });
-      handleMessage.resolves(null);
+      handleMessage.resolves(response.Messages[0]);
 
       consumer = new Consumer({
         queueUrl: QUEUE_URL,
@@ -1761,7 +1761,7 @@ describe("Consumer", () => {
       const deleteErr = new Error("Delete error");
       deleteErr.name = "SQSError";
 
-      handleMessage.resolves(null);
+      handleMessage.resolves(response.Messages[0]);
       sqs.send.withArgs(mockDeleteMessage).rejects(deleteErr);
 
       consumer.start();


### PR DESCRIPTION
Resolves #582

**Description:**

> [!IMPORTANT]
> This is a **breaking** change as it changes the expectation of the library completely, we need to ensure users are aware of this and that the release version and change log reflects this.

This makes acknowledgment of messages easier understand as the system is no explicit by default.

If the user does not explicitly return a message or messages, nothing will be acknowledged if the alwaysAcknowledge setting is not on.

This PR also improves the documentation.

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

Users find the acknowledgement of messages confusing.

**Code changes:**

- Changes the code to not acknowledge if anything other than an object or an array is returned and the always acknowledge setting is not on.
- Improves the documentation
