### PR TITLE
chore: prepare for return void deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ app.start();
   - It's also important to await any processing that you are doing to ensure that messages are processed one at a time.
 - **Message Acknowledgment Behavior**:
   - When `alwaysAcknowledge` is `false` (the default)
-    - **Returning `undefined` or `void`**: Message will **NOT** be deleted (left on queue for retry)
-    - **Returning an empty object `{}` or an empty array `[]`**: Message(s) will **NOT** be deleted
-    - **Returning the message object or an array of messages in batch processing**: Message(s) will be **acknowledged and deleted**
+    - **Returning `undefined`, an empty object `{}`, or an empty array `[]`**: Message(s) will **NOT** be deleted (left on queue for retry)
+      - For batch processing, return `undefined` or `[]` to prevent acknowledgment of all messages.
+      - For single message handling, return `undefined` or `{}` to prevent acknowledgment.
+    - **Returning the message object (or an array of messages in batch processing)**: Message(s) will be **acknowledged and deleted**
       - Important: Only the message id(s) that are returned will be deleted.
+    - **Returning `void` is discouraged and will be deprecated in a future release.**
   - **When `alwaysAcknowledge` is `true`:** All messages will be acknowledged and deleted regardless of return value.
 - **Error Handling**: Throwing an error (or returning a rejected promise) from the handler function will cause the message to be left on the queue. An [SQS redrive policy](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html) can be used to move messages that cannot be processed to a dead letter queue.
 - **Deletion Process** Messages are deleted from the queue once the handler function has completed successfully (the above items should also be taken into account).

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -44,8 +44,8 @@ export class Consumer extends TypedEventEmitter {
   protected queueUrl: string;
   private isFifoQueue: boolean;
   private suppressFifoWarning: boolean;
-  private handleMessage: (message: Message) => Promise<Message | void>;
-  private handleMessageBatch: (message: Message[]) => Promise<Message[] | void>;
+  private handleMessage: (message: Message) => Promise<Message | undefined>;
+  private handleMessageBatch: (messages: Message[]) => Promise<Message[] | undefined>;
   private preReceiveMessageCallback?: () => Promise<void>;
   private postReceiveMessageCallback?: () => Promise<void>;
   private sqs: SQSClient;
@@ -542,7 +542,7 @@ export class Consumer extends TypedEventEmitter {
     let handleMessageTimeoutId: NodeJS.Timeout | undefined = undefined;
 
     try {
-      let result: Message | void;
+      let result: Message | undefined | void;
 
       if (this.handleMessageTimeout) {
         const pending: Promise<void> = new Promise((_, reject): void => {
@@ -561,6 +561,15 @@ export class Consumer extends TypedEventEmitter {
 
       if (result instanceof Object) {
         return result;
+      }
+
+      if (result === undefined) {
+        return null;
+      }
+
+      if (result === null) {
+        console.warn('[DEPRECATION] Returning void from handleMessage is discouraged. Please return a Message or undefined.');
+        return null;
       }
 
       return null;
@@ -593,7 +602,7 @@ export class Consumer extends TypedEventEmitter {
    */
   private async executeBatchHandler(messages: Message[]): Promise<Message[]> {
     try {
-      const result: void | Message[] = await this.handleMessageBatch(messages);
+      const result: Message[] | undefined | void = await this.handleMessageBatch(messages);
 
       if (this.alwaysAcknowledge) {
         return messages;
@@ -603,12 +612,21 @@ export class Consumer extends TypedEventEmitter {
         return result;
       }
 
+      if (result === undefined) {
+        return [];
+      }
+
+      if (result === null) {
+        console.warn('[DEPRECATION] Returning void from handleMessageBatch is discouraged. Please return an array of Messages or undefined.');
+        return [];
+      }
+
       return [];
     } catch (err) {
       if (err instanceof Error) {
         throw toStandardError(
           err,
-          `Unexpected message handler failure: ${err.message}`,
+          `Unexpected message batch handler failure: ${err.message}`,
           messages,
         );
       }

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -544,7 +544,7 @@ export class Consumer extends TypedEventEmitter {
     let handleMessageTimeoutId: NodeJS.Timeout | undefined = undefined;
 
     try {
-      let result: Message | undefined | void;
+      let result: Message | undefined | null;
 
       if (this.handleMessageTimeout) {
         const pending: Promise<void> = new Promise((_, reject): void => {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -547,8 +547,8 @@ export class Consumer extends TypedEventEmitter {
       let result: Message | undefined | null;
 
       if (this.handleMessageTimeout) {
-        const pending: Promise<void> = new Promise((_, reject): void => {
-          handleMessageTimeoutId = setTimeout((): void => {
+        const pending: Promise<never> = new Promise<never>((_, reject) => {
+          handleMessageTimeoutId = setTimeout(() => {
             reject(new TimeoutError());
           }, this.handleMessageTimeout);
         });

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -45,7 +45,9 @@ export class Consumer extends TypedEventEmitter {
   private isFifoQueue: boolean;
   private suppressFifoWarning: boolean;
   private handleMessage: (message: Message) => Promise<Message | undefined>;
-  private handleMessageBatch: (messages: Message[]) => Promise<Message[] | undefined>;
+  private handleMessageBatch: (
+    messages: Message[],
+  ) => Promise<Message[] | undefined>;
   private preReceiveMessageCallback?: () => Promise<void>;
   private postReceiveMessageCallback?: () => Promise<void>;
   private sqs: SQSClient;
@@ -568,7 +570,9 @@ export class Consumer extends TypedEventEmitter {
       }
 
       if (result === null) {
-        console.warn('[DEPRECATION] Returning void from handleMessage is discouraged. Please return a Message or undefined.');
+        console.warn(
+          "[DEPRECATION] Returning void from handleMessage is discouraged. Please return a Message or undefined.",
+        );
         return null;
       }
 
@@ -602,7 +606,8 @@ export class Consumer extends TypedEventEmitter {
    */
   private async executeBatchHandler(messages: Message[]): Promise<Message[]> {
     try {
-      const result: Message[] | undefined | void = await this.handleMessageBatch(messages);
+      const result: Message[] | undefined | void =
+        await this.handleMessageBatch(messages);
 
       if (this.alwaysAcknowledge) {
         return messages;
@@ -617,7 +622,9 @@ export class Consumer extends TypedEventEmitter {
       }
 
       if (result === null) {
-        console.warn('[DEPRECATION] Returning void from handleMessageBatch is discouraged. Please return an array of Messages or undefined.');
+        console.warn(
+          "[DEPRECATION] Returning void from handleMessageBatch is discouraged. Please return an array of Messages or undefined.",
+        );
         return [];
       }
 

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -606,7 +606,7 @@ export class Consumer extends TypedEventEmitter {
    */
   private async executeBatchHandler(messages: Message[]): Promise<Message[]> {
     try {
-      const result: Message[] | undefined | void =
+      const result: Message[] | undefined | null =
         await this.handleMessageBatch(messages);
 
       if (this.alwaysAcknowledge) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,14 +127,16 @@ export interface ConsumerOptions {
    * a message is received.
    *
    * **Message Acknowledgment Behavior:**
-   * - Returning `undefined` or `void` will **NOT acknowledge** the message (leaves it on queue for retry)
-   * - Returning the original message will cause the message to be **acknowledged and deleted**
-   * - To **prevent acknowledgment**, return `undefined` or an empty object `{}`
+   * - Returning `undefined` will **NOT acknowledge** the message (leaves it on queue for retry)
+   * - Returning the original message or a processed message will cause the message to be **acknowledged and deleted**
    * - To **explicitly acknowledge** a specific message, return an object containing the MessageId you want to acknowledge
    *
    * **Important:** If `alwaysAcknowledge` is `true`, all messages will be acknowledged regardless of return value.
+   *
+   * @remarks
+   * Returning `void` is discouraged and will be deprecated in a future release. Please return a Message or `undefined`.
    */
-  handleMessage?(message: Message): Promise<Message | void>;
+  handleMessage?(message: Message): Promise<Message | undefined>;
   /**
    * An `async` function (or function that returns a `Promise`) to be called whenever
    * a batch of messages is received. Similar to `handleMessage` but will receive the
@@ -143,14 +145,17 @@ export interface ConsumerOptions {
    * **If both are set, `handleMessageBatch` overrides `handleMessage`**.
    *
    * **Message Acknowledgment Behavior:**
-   * - Returning `undefined` or `void` will **NOT acknowledge** any messages (leaves them on queue for retry)
-   * - Returning the original message array will cause **all messages to be acknowledged and deleted**
+   * - Returning `undefined` will **NOT acknowledge** any messages (leaves them on queue for retry)
+   * - Returning the original message array or a processed array will cause **all messages to be acknowledged and deleted**
    * - To **prevent acknowledgment** of all messages, return `undefined` or an empty array `[]`
    * - To **selectively acknowledge** messages, return an array containing only the messages you want to acknowledge
    *
    * **Important:** If `alwaysAcknowledge` is `true`, all messages will be acknowledged regardless of return value.
+   *
+   * @remarks
+   * Returning `void` is discouraged and will be deprecated in a future release. Please return an array of Messages or `undefined`.
    */
-  handleMessageBatch?(messages: Message[]): Promise<Message[] | void>;
+  handleMessageBatch?(messages: Message[]): Promise<Message[] | undefined>;
   /**
    * An `async` function (or function that returns a `Promise`) to be called right
    * before the SQS Client sends a receive message command.

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -76,7 +76,7 @@ describe("Consumer", () => {
     clock = sinon.useFakeTimers();
     handleMessage = sandbox.stub().resolves(response.Messages[0]);
     handleMessageBatch = sandbox.stub().resolves([]);
-    
+
     sqs = sinon.createStubInstance(SQSClient);
     sqs.send = sinon.stub();
 
@@ -1332,7 +1332,7 @@ describe("Consumer", () => {
       sandbox.assert.calledOnce(consoleWarnStub);
       sandbox.assert.calledWithMatch(
         consoleWarnStub,
-        "[DEPRECATION] Returning void from handleMessage is discouraged. Please return a Message or undefined."
+        "[DEPRECATION] Returning void from handleMessage is discouraged. Please return a Message or undefined.",
       );
     });
 
@@ -1531,7 +1531,7 @@ describe("Consumer", () => {
       sandbox.assert.calledOnce(consoleWarnStub);
       sandbox.assert.calledWithMatch(
         consoleWarnStub,
-        "[DEPRECATION] Returning void from handleMessageBatch is discouraged. Please return an array of Messages or undefined."
+        "[DEPRECATION] Returning void from handleMessageBatch is discouraged. Please return an array of Messages or undefined.",
       );
     });
 
@@ -2302,7 +2302,8 @@ describe("Consumer", () => {
       consumer = new Consumer({
         queueUrl: QUEUE_URL,
         region: REGION,
-        handleMessage: () => new Promise((resolve) => setTimeout(() => resolve(undefined), 20)),
+        handleMessage: () =>
+          new Promise((resolve) => setTimeout(() => resolve(undefined), 20)),
         sqs,
       });
 


### PR DESCRIPTION
Resolves #596

**Description:**

Allowing void to be returned is problematic, we should have never supported it. It was implemented in the old codebase and never deprecated, this moves us on the path of deprecating the ability to return void by removing the option from the types and adding a log warning if void is ever used.

This will be released as a patch as it should have been part of the last major release (apologies), shortly after, a major will come out with a full deprecation.
