### PR TITLE
fix: make coverage reports genhtml-compatible

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -93,12 +93,13 @@ export class Consumer extends TypedEventEmitter {
     this.alwaysAcknowledge = options.alwaysAcknowledge ?? false;
     this.extendedAWSErrors = options.extendedAWSErrors ?? false;
     this.strictReturn = options.strictReturn ?? false;
-    this.sqs =
-      options.sqs ||
-      new SQSClient({
-        useQueueUrlAsEndpoint: options.useQueueUrlAsEndpoint ?? true,
-        region: options.region || process.env.AWS_REGION || "eu-west-1",
-      });
+    if (options.sqs) {
+      this.sqs = options.sqs;
+    } else {
+      const useQueueUrlAsEndpoint = options.useQueueUrlAsEndpoint ?? true;
+      const region = options.region || process.env.AWS_REGION || "eu-west-1";
+      this.sqs = new SQSClient({ useQueueUrlAsEndpoint, region });
+    }
   }
 
   /**
@@ -131,10 +132,12 @@ export class Consumer extends TypedEventEmitter {
    * A reusable options object for sqs.send that's used to avoid duplication.
    */
   private get sqsSendOptions(): { abortSignal: AbortSignal } {
+    const abortSignal = this.abortController?.signal || new AbortController().signal;
+
     return {
       // return the current abortController signal or a fresh signal that has not been aborted.
       // This effectively defaults the signal sent to the AWS SDK to not aborted
-      abortSignal: this.abortController?.signal || new AbortController().signal,
+      abortSignal,
     };
   }
 
@@ -261,13 +264,15 @@ export class Consumer extends TypedEventEmitter {
         try {
           this.emitError(err);
         } catch (listenerErr) {
-          logger.warn(
-            `An error event listener threw an error: ${listenerErr instanceof Error ? listenerErr.message : String(listenerErr)}`,
-          );
+          const listenerErrorMessage =
+            listenerErr instanceof Error ? listenerErr.message : String(listenerErr);
+          logger.warn(`An error event listener threw an error: ${listenerErrorMessage}`);
         }
         if (isConnectionError(err)) {
+          const errorCode = err.code || "Unknown";
+
           logger.debug("authentication_error", {
-            code: err.code || "Unknown",
+            code: errorCode,
             detail: "There was an authentication error. Pausing before retrying.",
           });
           currentPollingTimeout = this.authenticationErrorTimeout;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,6 +2,9 @@ import type { Message } from "@aws-sdk/client-sqs";
 
 import type { AWSError } from "./types.js";
 
+const DEFAULT_TIMEOUT_ERROR_MESSAGE = "Operation timed out.";
+const DEFAULT_STANDARD_ERROR_MESSAGE = "An unexpected error occurred:";
+
 class SQSError extends Error {
   code: string;
   cause: AWSError;
@@ -26,9 +29,11 @@ class TimeoutError extends Error {
   cause: Error;
   time: Date;
 
-  constructor(message = "Operation timed out.") {
-    super(message);
-    this.message = message;
+  constructor(message?: string) {
+    const errorMessage = message === undefined ? DEFAULT_TIMEOUT_ERROR_MESSAGE : message;
+
+    super(errorMessage);
+    this.message = errorMessage;
     this.name = "TimeoutError";
     this.messageIds = [];
   }
@@ -39,9 +44,11 @@ class StandardError extends Error {
   cause: Error;
   time: Date;
 
-  constructor(message = "An unexpected error occurred:") {
-    super(message);
-    this.message = message;
+  constructor(message?: string) {
+    const errorMessage = message === undefined ? DEFAULT_STANDARD_ERROR_MESSAGE : message;
+
+    super(errorMessage);
+    this.message = errorMessage;
     this.name = "StandardError";
     this.messageIds = [];
   }

--- a/test/tests/errors.test.ts
+++ b/test/tests/errors.test.ts
@@ -1,0 +1,34 @@
+import { assert } from "chai";
+import { describe, it } from "vitest";
+
+import { StandardError, TimeoutError } from "../../src/errors.js";
+
+describe("errors", () => {
+  describe("TimeoutError", () => {
+    it("uses the default message when none is provided", () => {
+      const error = new TimeoutError();
+
+      assert.equal(error.message, "Operation timed out.");
+    });
+
+    it("uses the provided message", () => {
+      const error = new TimeoutError("Custom timeout.");
+
+      assert.equal(error.message, "Custom timeout.");
+    });
+  });
+
+  describe("StandardError", () => {
+    it("uses the default message when none is provided", () => {
+      const error = new StandardError();
+
+      assert.equal(error.message, "An unexpected error occurred:");
+    });
+
+    it("uses the provided message", () => {
+      const error = new StandardError("Custom failure.");
+
+      assert.equal(error.message, "Custom failure.");
+    });
+  });
+});


### PR DESCRIPTION
The coverage workflow failed while generating the HTML report because V8/Vitest emitted branch records for lines that had no line coverage data. This showed up first in the error constructors, then in similar short-circuit and inline conditional paths in the consumer.

- Preserve existing error defaults while moving constructor defaults into executable bodies.
- Add direct coverage for default and custom error messages.
- Refactor consumer short-circuit/inline conditional expressions into ordinary local assignments.
- Keep runtime behaviour unchanged while producing valid LCOV for the PR coverage action.
