### PR TITLE
feat: add a warning when using a non-AWS queue URL as the endpoint

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -30,7 +30,7 @@ import {
   toSQSError,
   isConnectionError,
 } from "./errors.js";
-import { validateOption, assertOptions, hasMessages } from "./validation.js";
+import { validateOption, assertOptions, hasMessages, isAwsQueueUrl } from "./validation.js";
 import { logger } from "./logger.js";
 
 /**
@@ -66,6 +66,7 @@ export class Consumer extends TypedEventEmitter {
   public abortController: AbortController;
   private extendedAWSErrors: boolean;
   private strictReturn: boolean;
+  private shouldWarnAboutQueueUrlEndpoint: boolean;
 
   constructor(options: ConsumerOptions) {
     super(options.queueUrl);
@@ -93,11 +94,13 @@ export class Consumer extends TypedEventEmitter {
     this.alwaysAcknowledge = options.alwaysAcknowledge ?? false;
     this.extendedAWSErrors = options.extendedAWSErrors ?? false;
     this.strictReturn = options.strictReturn ?? false;
+    this.shouldWarnAboutQueueUrlEndpoint = false;
     if (options.sqs) {
       this.sqs = options.sqs;
     } else {
       const useQueueUrlAsEndpoint = options.useQueueUrlAsEndpoint ?? true;
       const region = options.region || process.env.AWS_REGION || "eu-west-1";
+      this.shouldWarnAboutQueueUrlEndpoint = useQueueUrlAsEndpoint && !isAwsQueueUrl(this.queueUrl);
       this.sqs = new SQSClient({ useQueueUrlAsEndpoint, region });
     }
   }
@@ -117,6 +120,11 @@ export class Consumer extends TypedEventEmitter {
       if (this.isFifoQueue && !this.suppressFifoWarning) {
         logger.warn(
           "WARNING: A FIFO queue was detected. SQS Consumer does not guarantee FIFO queues will work as expected. Set 'suppressFifoWarning: true' to disable this warning.",
+        );
+      }
+      if (this.shouldWarnAboutQueueUrlEndpoint) {
+        logger.warn(
+          "WARNING: A non-AWS queue URL was provided while useQueueUrlAsEndpoint is enabled. SQS Consumer will use the queueUrl hostname as the request endpoint. Treat queueUrl as trusted application configuration or set 'useQueueUrlAsEndpoint: false' to use the client's resolved endpoint.",
         );
       }
       // Create a new abort controller each time the consumer is started

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,14 @@ export interface ConsumerOptions {
   /**
    * Set this value to false to ignore the `queueUrl` and use the
    * client's resolved endpoint, which may be a custom endpoint.
+   *
+   * Treat `queueUrl` as trusted application configuration. If your application
+   * accepts queue URLs from users or other external sources, validate those
+   * values before passing them to SQS Consumer, or set this option to `false`
+   * when that is compatible with your SQS setup. When this option is enabled
+   * and `queueUrl` does not point to an AWS endpoint, SQS Consumer will log a
+   * warning.
+   *
    * @defaultValue `true`
    */
   useQueueUrlAsEndpoint?: boolean;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -71,15 +71,21 @@ function assertOptions(options: ConsumerOptions): void {
 function isAwsQueueUrl(queueUrl: string): boolean {
   try {
     const parsedQueueUrl = new URL(queueUrl);
-    const hostname = parsedQueueUrl.hostname.toLowerCase();
 
-    return (
-      parsedQueueUrl.protocol === "https:" &&
-      (hostname.endsWith(".amazonaws.com") || hostname.endsWith(".api.aws"))
-    );
+    if (parsedQueueUrl.protocol !== "https:") {
+      return false;
+    }
+
+    return isAwsQueueHostname(parsedQueueUrl.hostname);
   } catch {
     return false;
   }
+}
+
+function isAwsQueueHostname(hostname: string): boolean {
+  const normalisedHostname = hostname.toLowerCase();
+
+  return normalisedHostname.endsWith(".amazonaws.com") || normalisedHostname.endsWith(".api.aws");
 }
 
 /**

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -84,8 +84,9 @@ function isAwsQueueUrl(queueUrl: string): boolean {
 
 function isAwsQueueHostname(hostname: string): boolean {
   const normalisedHostname = hostname.toLowerCase();
+  const awsHostSuffixes = [".amazonaws.com", ".amazonaws.com.cn", ".api.aws"];
 
-  return normalisedHostname.endsWith(".amazonaws.com") || normalisedHostname.endsWith(".api.aws");
+  return awsHostSuffixes.some((suffix) => normalisedHostname.endsWith(suffix));
 }
 
 /**

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -68,6 +68,20 @@ function assertOptions(options: ConsumerOptions): void {
   }
 }
 
+function isAwsQueueUrl(queueUrl: string): boolean {
+  try {
+    const parsedQueueUrl = new URL(queueUrl);
+    const hostname = parsedQueueUrl.hostname.toLowerCase();
+
+    return (
+      parsedQueueUrl.protocol === "https:" &&
+      (hostname.endsWith(".amazonaws.com") || hostname.endsWith(".api.aws"))
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Determine if the response from SQS has messages in it.
  * @param response The response from SQS.
@@ -76,4 +90,4 @@ function hasMessages(response: ReceiveMessageCommandOutput): boolean {
   return response.Messages && response.Messages.length > 0;
 }
 
-export { hasMessages, assertOptions, validateOption };
+export { hasMessages, assertOptions, validateOption, isAwsQueueUrl };

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -2144,6 +2144,20 @@ describe("Consumer", () => {
       sandbox.assert.calledOnce(pollStub);
     });
 
+    it("does not emit a warning when the queue URL is the amazonaws.com.cn endpoint", () => {
+      consumer = new Consumer({
+        queueUrl: "https://sqs.cn-north-1.amazonaws.com.cn/123456789012/queue",
+        region: REGION,
+        handleMessage,
+      });
+
+      consumer.start();
+      consumer.stop();
+
+      sandbox.assert.notCalled(warnStub);
+      sandbox.assert.calledOnce(pollStub);
+    });
+
     it("does not emit a warning when the queue URL is the api.aws endpoint", () => {
       consumer = new Consumer({
         queueUrl: "https://sqs.us-east-1.api.aws/123456789012/queue",

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -2089,6 +2089,106 @@ describe("Consumer", () => {
     });
   });
 
+  describe("queue URL endpoint warning", () => {
+    let warnStub: sinon.SinonStub;
+    let pollStub: sinon.SinonStub;
+    let originalPrototype: { poll: () => void };
+    let originalPoll: () => void;
+
+    beforeEach(() => {
+      warnStub = sandbox.stub(logger, "warn");
+      pollStub = sandbox.stub();
+      originalPrototype = Object.getPrototypeOf(consumer);
+      originalPoll = originalPrototype.poll;
+
+      Object.defineProperty(originalPrototype, "poll", {
+        value: pollStub,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(originalPrototype, "poll", {
+        value: originalPoll,
+      });
+    });
+
+    it("emits a warning when using a non-AWS queue URL as the endpoint", () => {
+      consumer = new Consumer({
+        queueUrl: "http://localhost:9324/000000000000/sqs-consumer-data",
+        region: REGION,
+        handleMessage,
+      });
+
+      consumer.start();
+      consumer.stop();
+
+      sandbox.assert.calledOnce(warnStub);
+      sandbox.assert.calledWithMatch(
+        warnStub,
+        "WARNING: A non-AWS queue URL was provided while useQueueUrlAsEndpoint is enabled.",
+      );
+      sandbox.assert.calledOnce(pollStub);
+    });
+
+    it("does not emit a warning when the queue URL is the amazonaws.com endpoint", () => {
+      consumer = new Consumer({
+        queueUrl: "https://sqs.us-east-1.amazonaws.com/123456789012/queue",
+        region: REGION,
+        handleMessage,
+      });
+
+      consumer.start();
+      consumer.stop();
+
+      sandbox.assert.notCalled(warnStub);
+      sandbox.assert.calledOnce(pollStub);
+    });
+
+    it("does not emit a warning when the queue URL is the api.aws endpoint", () => {
+      consumer = new Consumer({
+        queueUrl: "https://sqs.us-east-1.api.aws/123456789012/queue",
+        region: REGION,
+        handleMessage,
+      });
+
+      consumer.start();
+      consumer.stop();
+
+      sandbox.assert.notCalled(warnStub);
+      sandbox.assert.calledOnce(pollStub);
+    });
+
+    it("does not emit a warning when queue URLs are not used as endpoints", () => {
+      consumer = new Consumer({
+        queueUrl: "http://localhost:9324/000000000000/sqs-consumer-data",
+        region: REGION,
+        handleMessage,
+        useQueueUrlAsEndpoint: false,
+      });
+
+      consumer.start();
+      consumer.stop();
+
+      sandbox.assert.notCalled(warnStub);
+      sandbox.assert.calledOnce(pollStub);
+    });
+
+    it("does not emit a warning when a custom SQS client is provided", () => {
+      consumer = new Consumer({
+        queueUrl: "http://localhost:9324/000000000000/sqs-consumer-data",
+        region: REGION,
+        handleMessage,
+        sqs,
+      });
+
+      consumer.start();
+      consumer.stop();
+
+      sandbox.assert.notCalled(warnStub);
+      sandbox.assert.calledOnce(pollStub);
+    });
+  });
+
   describe("event listeners", () => {
     it("fires the event multiple times", async () => {
       sqs.send.withArgs(mockReceiveMessage).resolves({});

--- a/test/tests/validation.test.ts
+++ b/test/tests/validation.test.ts
@@ -1,0 +1,26 @@
+import { assert } from "chai";
+import { describe, it } from "vitest";
+
+import { isAwsQueueUrl } from "../../src/validation.js";
+
+describe("validation", () => {
+  describe("isAwsQueueUrl", () => {
+    it("returns true for AWS queue URLs", () => {
+      assert.isTrue(isAwsQueueUrl("https://sqs.eu-west-1.amazonaws.com/123456789012/queue"));
+      assert.isTrue(isAwsQueueUrl("https://sqs.eu-west-1.api.aws/123456789012/queue"));
+    });
+
+    it("returns false for non-HTTPS AWS queue URLs", () => {
+      assert.isFalse(isAwsQueueUrl("http://sqs.eu-west-1.amazonaws.com/123456789012/queue"));
+    });
+
+    it("returns false for non-AWS queue URLs", () => {
+      assert.isFalse(isAwsQueueUrl("http://localhost:9324/000000000000/sqs-consumer-data"));
+      assert.isFalse(isAwsQueueUrl("https://example.com/000000000000/sqs-consumer-data"));
+    });
+
+    it("returns false for invalid queue URLs", () => {
+      assert.isFalse(isAwsQueueUrl("not-a-url"));
+    });
+  });
+});

--- a/test/tests/validation.test.ts
+++ b/test/tests/validation.test.ts
@@ -7,6 +7,7 @@ describe("validation", () => {
   describe("isAwsQueueUrl", () => {
     it("returns true for AWS queue URLs", () => {
       assert.isTrue(isAwsQueueUrl("https://sqs.eu-west-1.amazonaws.com/123456789012/queue"));
+      assert.isTrue(isAwsQueueUrl("https://sqs.eu-west-1.amazonaws.com.cn/123456789012/queue"));
       assert.isTrue(isAwsQueueUrl("https://sqs.eu-west-1.api.aws/123456789012/queue"));
     });
 


### PR DESCRIPTION
This will show a warning to the user if they use a non aws queue url while useQueueUrlAsEndpoint is set to true.

It also updates the type documentation to provide advice about how to use this setting.

still thinking about if the warning is really needed tbh.