### PR TITLE
fix: wait for an in flight heartbeat before deleting the message

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -22,7 +22,7 @@ import type {
   MessageSystemAttributeName,
 } from "@aws-sdk/client-sqs";
 
-import type { ConsumerOptions, StopOptions, UpdatableOptions } from "./types.js";
+import type { ConsumerOptions, Heartbeat, StopOptions, UpdatableOptions } from "./types.js";
 import { TypedEventEmitter } from "./emitter.js";
 import {
   SQSError,
@@ -349,17 +349,22 @@ export class Consumer extends TypedEventEmitter {
    */
   private async processMessage(message: Message): Promise<void> {
     let heartbeatTimeoutId: NodeJS.Timeout | undefined = undefined;
+    const heartbeat: Heartbeat = {};
 
     try {
       this.emit("message_received", message);
 
       if (this.heartbeatInterval) {
-        heartbeatTimeoutId = this.startHeartbeat(message);
+        heartbeatTimeoutId = this.startHeartbeat(heartbeat, message);
       }
 
       const ackedMessage: Message = await this.executeHandler(message);
 
       if (ackedMessage?.MessageId === message.MessageId) {
+        if (this.heartbeatInterval) {
+          await this.stopHeartbeat(heartbeatTimeoutId, heartbeat);
+        }
+
         await this.deleteMessage(message);
 
         this.emit("message_processed", message);
@@ -390,6 +395,7 @@ export class Consumer extends TypedEventEmitter {
    */
   private async processMessageBatch(messages: Message[]): Promise<void> {
     let heartbeatTimeoutId: NodeJS.Timeout | undefined = undefined;
+    const heartbeat: Heartbeat = {};
 
     try {
       messages.forEach((message: Message): void => {
@@ -397,12 +403,16 @@ export class Consumer extends TypedEventEmitter {
       });
 
       if (this.heartbeatInterval) {
-        heartbeatTimeoutId = this.startHeartbeat(null, messages);
+        heartbeatTimeoutId = this.startHeartbeat(heartbeat, null, messages);
       }
 
       const ackedMessages: Message[] = await this.executeBatchHandler(messages);
 
       if (ackedMessages?.length > 0) {
+        if (this.heartbeatInterval) {
+          await this.stopHeartbeat(heartbeatTimeoutId, heartbeat);
+        }
+
         const deletedMessages = await this.deleteMessageBatch(ackedMessages);
 
         deletedMessages.forEach((message: Message): void => {
@@ -429,16 +439,40 @@ export class Consumer extends TypedEventEmitter {
 
   /**
    * Trigger a function on a set interval
-   * @param heartbeatFn The function that should be triggered
+   * @param heartbeat Keeps track of the visibility timeout change that is currently in flight
+   * @param message The message to extend the visibility timeout of
+   * @param messages The messages to extend the visibility timeout of
    */
-  private startHeartbeat(message?: Message, messages?: Message[]): NodeJS.Timeout {
+  private startHeartbeat(
+    heartbeat: Heartbeat,
+    message?: Message,
+    messages?: Message[],
+  ): NodeJS.Timeout {
     return setInterval(() => {
-      if (this.handleMessageBatch) {
-        return this.changeVisibilityTimeoutBatch(messages, this.visibilityTimeout);
-      }
+      heartbeat.inFlight = this.handleMessageBatch
+        ? this.changeVisibilityTimeoutBatch(messages, this.visibilityTimeout)
+        : this.changeVisibilityTimeout(message, this.visibilityTimeout);
 
-      return this.changeVisibilityTimeout(message, this.visibilityTimeout);
+      return heartbeat.inFlight;
     }, this.heartbeatInterval * 1000);
+  }
+
+  /**
+   * Stop extending the visibility timeout of a message that has finished being processed.
+   *
+   * Waiting for the tick that is already in flight is what makes this safe to call before
+   * deleting: `clearInterval` only cancels future ticks, so a tick still on its way to SQS would
+   * otherwise be able to land after the delete, and fail with "Message does not exist or is not
+   * available for visibility timeout change".
+   * @param heartbeatTimeoutId The interval to cancel
+   * @param heartbeat The visibility timeout change that is currently in flight, if any
+   */
+  private async stopHeartbeat(
+    heartbeatTimeoutId: NodeJS.Timeout | undefined,
+    heartbeat: Heartbeat,
+  ): Promise<void> {
+    clearInterval(heartbeatTimeoutId);
+    await heartbeat.inFlight;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -220,6 +220,14 @@ export interface QueueMetadata {
 }
 
 /**
+ * Keeps track of the visibility timeout change that the heartbeat currently has in flight,
+ * so that it can be waited on before the message is deleted.
+ */
+export interface Heartbeat {
+  inFlight?: Promise<unknown>;
+}
+
+/**
  * These are the events that the consumer emits.
  * Each event will receive QueueMetadata as the last argument, which is added automatically by the emitter.
  * @example

--- a/test/tests/consumer.test.ts
+++ b/test/tests/consumer.test.ts
@@ -1794,6 +1794,55 @@ describe("Consumer", () => {
       sandbox.assert.calledOnce(clearIntervalSpy);
     });
 
+    it("waits for an in flight heartbeat before deleting the message", async () => {
+      // SQS rejects a visibility timeout change for a message that has already been deleted, so a
+      // heartbeat that is still on its way out when the handler finishes must be given the chance
+      // to land first.
+      let deleted = false;
+      sqs.send.withArgs(mockDeleteMessage).callsFake(async () => {
+        deleted = true;
+      });
+      sqs.send.withArgs(mockChangeMessageVisibility).callsFake(
+        () =>
+          new Promise((resolve, reject) =>
+            setTimeout(() => {
+              if (deleted) {
+                reject(
+                  new MockSQSError(
+                    "Value receipt-handle for parameter ReceiptHandle is invalid. Reason: " +
+                      "Message does not exist or is not available for visibility timeout change.",
+                  ),
+                );
+              } else {
+                resolve({});
+              }
+            }, 50),
+          ),
+      );
+
+      consumer = new Consumer({
+        queueUrl: QUEUE_URL,
+        region: REGION,
+        // Finishes a millisecond after the heartbeat has fired, while it is still in flight.
+        handleMessage: () =>
+          new Promise((resolve) => setTimeout(() => resolve(response.Messages[0]), 30001)),
+        sqs,
+        visibilityTimeout: 40,
+        heartbeatInterval: 30,
+      });
+
+      const errorListener = sandbox.stub();
+      consumer.on("error", errorListener);
+
+      consumer.start();
+      await Promise.all([pEvent(consumer, "message_processed"), clock.tickAsync(30200)]);
+      consumer.stop();
+
+      sandbox.assert.calledWith(sqs.send, mockChangeMessageVisibility);
+      sandbox.assert.calledWith(sqs.send, mockDeleteMessage);
+      sandbox.assert.notCalled(errorListener);
+    });
+
     it("passes in the correct visibility timeout for long running batch handler functions", async () => {
       sqs.send.withArgs(mockReceiveMessage).resolves({
         Messages: [


### PR DESCRIPTION
**Description:**

When `heartbeatInterval` is set, the consumer occasionally emits an `error` for a message that was
processed and deleted perfectly fine:

```
Error changing visibility timeout: Value <receipt-handle> for parameter ReceiptHandle is invalid.
Reason: Message does not exist or is not available for visibility timeout change.
```

This makes the heartbeat wait for its in-flight request before the message is deleted, so the
spurious error no longer happens.

**Type of change:**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

`startHeartbeat` runs on a `setInterval` and does not await its `changeMessageVisibility` call, so a
tick that fires shortly before the handler resolves can still be travelling to SQS while
`deleteMessage` runs. If it arrives after the delete, the receipt handle is already gone and SQS
rejects it, which surfaces as an `error` event even though the message was handled exactly once.

`clearInterval` in the `finally` block cannot prevent this, because it only cancels *future* ticks —
the request already in flight is beyond its reach.

It only shows up when a handler happens to finish within a few milliseconds before a tick, so it is
rare but persistent. The affected messages are handled correctly throughout: the error is emitted
right after a successful delete, and they are never redelivered — the only symptom is the misleading
error itself.

**Code changes:**

- `startHeartbeat` now stores the promise of the visibility timeout change it has in flight, so the
  caller can wait for it. It takes a small mutable `Heartbeat` holder rather than returning it,
  because `processMessage` runs concurrently for each message in a batch and the interval callback
  needs somewhere per-message to record it.
- Added `stopHeartbeat`, which clears the interval and awaits that in-flight tick. Awaiting it is
  what closes the window: once it has settled, no heartbeat request can still be on its way to SQS.
- `processMessage` and `processMessageBatch` call `stopHeartbeat` right before deleting. The
  `finally` blocks are left untouched so the error paths keep clearing the interval exactly as
  before.
- Waiting adds no latency in the normal case: `heartbeat.inFlight` is either unset or already
  settled, so the `await` resolves immediately. It only ever waits in the rare case that is
  currently producing the error.

---

**Checklist:**

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

The new test models SQS's actual behaviour — the visibility timeout change only fails once the
message has been deleted — so it fails without this change and passes with it. The existing 121 unit
tests pass unmodified. `npm run typecheck`, `npm run lint` and `npm run format:check` are all clean.
I was not able to run the integration suite locally, so that one is down to CI.
